### PR TITLE
Remove beaker dependency, auto required by beaker-rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
   gem 'puppet-lint',             :require => false
   gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
-  gem 'beaker-rspec',            :require => false, :platform => :ruby
+  gem 'beaker-rspec',            :require => false, :platforms => :ruby
 end
 
 # see http://projects.puppetlabs.com/issues/21698


### PR DESCRIPTION
Pin gem beaker-rspec to :platform => :ruby which will not install on windows
