### PR TITLE
[DO NOT MERGE](maint) add AppVeyor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "facter", *location_for(ENV['FACTER_LOCATION'] || '>= 1')
 gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '>= 1')
 
 beaker_version = ENV['BEAKER_VERSION']
-beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION'] || '~> 4.0'
+beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION'] #|| '~> 4.0'
 group :development, :test do
   gem 'rspec'
   gem 'mocha'
@@ -31,6 +31,8 @@ group :development, :test do
   gem 'simplecov',               :require => false
   if beaker_version
     gem 'beaker', *location_for(beaker_version)
+  else
+    gem 'beaker',                :require => false, :platforms => :ruby
   end
   if beaker_rspec_version
     gem 'beaker-rspec', *location_for(beaker_rspec_version)
@@ -43,6 +45,7 @@ end
 platforms :mswin, :mingw do
   gem "ffi", "~> 1.9", :require => false
   gem "sys-admin", "~> 1.5.6", :require => false
+  gem "win32-api", "~> 1.4.8", :require => false
   gem "win32-dir", "~> 0.3", :require => false
   gem "win32-eventlog", "~> 0.5", :require => false
   gem "win32-process", "~> 0.6", :require => false
@@ -50,6 +53,8 @@ platforms :mswin, :mingw do
   gem "win32-service", "~> 0.7", :require => false
   gem "win32-taskscheduler", "~> 0.2", :require => false
   gem "win32console", "~> 1.3", :require => false
+  gem "windows-api", "~> 0.4", :require => false
+  gem "windows-pr", "~> 1.2", :require => false
   gem "minitar", "~> 0.5.4", :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,14 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "puppet", *location_for(ENV['PUPPET_LOCATION'] || '~> 3.4.0')
-gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 1.6')
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion,  :require => false
+else
+  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || '~> 3')
+end
+
+gem "facter", *location_for(ENV['FACTER_LOCATION'] || '>= 1')
+gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '>= 1')
 
 beaker_version = ENV['BEAKER_VERSION']
 beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION'] || '~> 4.0'
@@ -36,14 +41,15 @@ end
 
 # see http://projects.puppetlabs.com/issues/21698
 platforms :mswin, :mingw do
+  gem "ffi", "~> 1.9", :require => false
   gem "sys-admin", "~> 1.5.6", :require => false
-  gem "win32-dir", "~> 0.3.7", :require => false
-  gem "win32-eventlog", "~> 0.5.3", :require => false
-  gem "win32-process", "~> 0.6.5", :require => false
-  gem "win32-security", "~> 0.1.4", :require => false
-  gem "win32-service", "~> 0.7.2", :require => false
-  gem "win32-taskscheduler", "~> 0.2.2", :require => false
-  gem "win32console", "~> 1.3.2", :require => false
+  gem "win32-dir", "~> 0.3", :require => false
+  gem "win32-eventlog", "~> 0.5", :require => false
+  gem "win32-process", "~> 0.6", :require => false
+  gem "win32-security", "~> 0.1", :require => false
+  gem "win32-service", "~> 0.7", :require => false
+  gem "win32-taskscheduler", "~> 0.2", :require => false
+  gem "win32console", "~> 1.3", :require => false
   gem "minitar", "~> 0.5.4", :require => false
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+version: 1.0.x.{build}
+platform:
+- x64
+clone_depth: 10
+init:
+- SET
+- 'mkdir C:\ProgramData\PuppetLabs\code && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\facter && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
+environment:
+  matrix:
+  - PUPPET_GEM_VERSION: 3.4.3
+    RUBY_VER: 193
+  - PUPPET_GEM_VERSION: 3.7.5
+    RUBY_VER: 193
+  - PUPPET_GEM_VERSION: 3.7.5
+    RUBY_VER: 200-x64
+  - PUPPET_GEM_VERSION: 4.0.0
+    RUBY_VER: 215
+  - PUPPET_GEM_VERSION: 4.0.0
+    RUBY_VER: 215-x64
+install:
+- SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+- gem install bundler --quiet --no-ri --no-rdoc
+- bundle install --without development test
+- type Gemfile.lock
+build: off
+test_script:
+- bundle exec puppet -V
+- ruby -v
+- bundle exec rspec spec

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.x.{build}
-platform:
-- x64
+skip_commits:
+  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
 clone_depth: 10
 init:
 - SET
@@ -17,16 +17,25 @@ environment:
   - PUPPET_GEM_VERSION: 3.7.5
     RUBY_VER: 200-x64
   - PUPPET_GEM_VERSION: 4.0.0
-    RUBY_VER: 215
+    RUBY_VER: 21
   - PUPPET_GEM_VERSION: 4.0.0
-    RUBY_VER: 215-x64
+    RUBY_VER: 21-x64
+matrix:
+  fast_finish: true
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
 - gem install bundler --quiet --no-ri --no-rdoc
-- bundle install --without development test
+- bundle install --jobs 4 --retry 2 --without development
 - type Gemfile.lock
 build: off
 test_script:
 - bundle exec puppet -V
 - ruby -v
-- bundle exec rspec spec
+- bundle exec rspec spec/unit -fd -b
+notifications:
+- provider: Email
+  to:
+  - nobody@nowhere.com
+  on_build_success: false
+  on_build_failure: false
+  on_build_status_changed: false


### PR DESCRIPTION

Add AppVeyor to PowerShell module.

- Matrix - Run against several supported versions of Puppet
- Notify the Ruby / Puppet versions
- Capture Environment vars / Gemfile.lock contents
- Ensure Administrator - AppVeyor doesn't have an Administrator account
by default, so put the adminstrator account back for specs to pass
- create top level Puppet data folders - puppet runs on Windows fails
until the folders exist