### PR TITLE
(MODULES-2207) bin beaker-rspec to ~> 5.1

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,7 +10,7 @@ Gemfile:
     ':development':
       - gem: rake
       - gem: rspec
-        version: '~>2.14.1'
+        version: '~>3.0.0'
       - gem: puppet-lint
       - gem: puppetlabs_spec_helper
       - gem: puppet_facts

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 group :development do
   gem 'rake',                    :require => false
-  gem 'rspec', '~>2.14.1',       :require => false
+  gem 'rspec', '~>3.0.0',        :require => false
   gem 'puppet-lint',             :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet_facts',            :require => false
@@ -36,11 +36,7 @@ end
 
 group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
-  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec',  :require => false
-  end
+  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
   gem 'beaker-puppet_install_helper',  :require => false
 end
 


### PR DESCRIPTION
Ensure that beaker rspec is at least on a version that supports the
use of specinfra and is not known to contain bugs.