### PR TITLE
MODULES-2774: replace powershell script invocation way to ampersand .…

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
       # we redirect powershell's stdin to read from the file. Current
       # versions of Windows use per-user temp directories with strong
       # permissions, but I'd rather not make (poor) assumptions.
-      return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{args} -Command - < \"#{native_path}\"\"", check)
+      return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{args} -Command \"& \'#{native_path}\'\"", check)
     end
   end
 
@@ -51,6 +51,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     Tempfile.open(['puppet-powershell', '.ps1']) do |file|
       file.write(content)
       file.flush
+      file.close
       yield native_path(file.path)
     end
   end


### PR DESCRIPTION
The method I've fixed that issue is:
using & approach invoking the PS script:
```
return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{args} -Command \"& \'#{native_path}\'\"", check)
```

and closing the handler (yeah, I know that you wanna get better security, but...)
```
      file.write(content)
      file.flush
      file.close
```