### PR TITLE
(FM-4881) Remove gem install bundler on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ matrix:
   fast_finish: true
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
-- gem install bundler --quiet --no-ri --no-rdoc
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock
 build: off


### PR DESCRIPTION
Running gem install bundler on appveyor is redundant because it is already present.
Removing it will speed up build times