### PR TITLE
(MODULES-2962) Reuse PowerShell Session

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -15,4 +15,4 @@ appveyor.yml:
     - PUPPET_GEM_VERSION: 3.0.0
       RUBY_VER: 193
   test_script:
-    - 'bundle exec rspec spec/unit -fd -b'
+    - 'bundle exec rspec spec/unit spec/integration -fd -b'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build: off
 test_script:
 - bundle exec puppet -V
 - ruby -v
-- bundle exec rspec spec/unit -fd -b
+- bundle exec rspec spec/unit spec/integration -fd -b
 notifications:
 - provider: Email
   to:

--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -1,4 +1,5 @@
 require 'puppet/provider/exec'
+require_relative '../../../puppet_x/puppetlabs/powershell_manager'
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
   confine :operatingsystem => :windows
@@ -25,17 +26,65 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
         }
   EOT
 
+  def self.upgrade_message
+    Puppet.warning <<-UPGRADE
+The current Puppet version is outdated and uses a library that was
+previously necessary on the current Ruby verison to support a colored console.
+
+Unfortunately this library prevents the PowerShell module from using a shared
+PowerShell process to dramatically improve the performance of resource
+application.
+
+To enable these improvements, it is suggested to upgrade to any x64 version of
+Puppet (including 3.x), or to a Puppet version newer than 3.x.
+    UPGRADE
+  end
+
+  if !PuppetX::PowerShell::PowerShellManager.supported?
+    upgrade_message
+  end
+
+  def self.powershell_args
+    ps_args = ['-NoProfile', '-NonInteractive', '-Sta', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
+    ps_args << '-' if PuppetX::PowerShell::PowerShellManager.supported?
+    ps_args
+  end
+
+  def ps_manager
+    PuppetX::PowerShell::PowerShellManager.instance("#{command(:powershell)} #{self.class.powershell_args.join(' ')}")
+  end
+
   def run(command, check = false)
-    write_script(command) do |native_path|
-      # Ideally, we could keep a handle open on the temp file in this
-      # process (to prevent TOCTOU attacks), and execute powershell
-      # with -File <path>. But powershell complains that it can't open
-      # the file for exclusive access. If we close the handle, then an
-      # attacker could modify the file before we invoke powershell. So
-      # we redirect powershell's stdin to read from the file. Current
-      # versions of Windows use per-user temp directories with strong
-      # permissions, but I'd rather not make (poor) assumptions.
-      return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{args} -Command - < \"#{native_path}\"\"", check)
+    if !PuppetX::PowerShell::PowerShellManager.supported?
+      write_script(command) do |native_path|
+        # Ideally, we could keep a handle open on the temp file in this
+        # process (to prevent TOCTOU attacks), and execute powershell
+        # with -File <path>. But powershell complains that it can't open
+        # the file for exclusive access. If we close the handle, then an
+        # attacker could modify the file before we invoke powershell. So
+        # we redirect powershell's stdin to read from the file. Current
+        # versions of Windows use per-user temp directories with strong
+        # permissions, but I'd rather not make (poor) assumptions.
+        return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
+      end
+    else
+      result = ps_manager.execute(command)
+
+      stdout      = result[:stdout]
+      stderr      = result[:stderr]
+      exit_code   = result[:exitcode]
+
+      unless stderr.nil?
+        stderr.each do |er|
+          er.each { |e| Puppet.debug "STDERR: #{e.chop}" } unless er.empty?
+        end
+      end
+
+      Puppet.debug "STDERR: #{result[:errormessage]}" unless result[:errormessage].nil?
+
+      output = Puppet::Util::Execution::ProcessOutput.new(stdout.to_s || '', exit_code)
+
+      return output, output
     end
   end
 
@@ -63,7 +112,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     end
   end
 
-  def args
+  def legacy_args
     '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass'
   end
 end

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -1,0 +1,222 @@
+require 'securerandom'
+require 'open3'
+require 'ffi'
+
+module PuppetX
+  module Dsc
+    class PowerShellManager
+      extend Puppet::Util::Windows::String
+      extend FFI::Library
+
+      @@instances = {}
+
+      def self.instance(cmd)
+        @@instances[:cmd] ||= PowerShellManager.new(cmd)
+      end
+
+      def initialize(cmd)
+        @stdin, @stdout, @ps_process = Open3.popen2(cmd)
+
+        Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
+
+        at_exit { exit }
+      end
+
+      def execute(powershell_code, timeout_ms = 300 * 1000)
+        output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
+        output_ready_event = self.class.create_event(output_ready_event_name)
+
+        # always need a trailing newline to ensure PowerShell parses code
+        code = <<-CODE
+        $event = [Threading.EventWaitHandle]::OpenExisting("#{output_ready_event_name}")
+        if ($runspace -eq $null)
+        {
+          $runspace = [RunspaceFactory]::CreateRunspace()
+          $runspace.Open()
+        }
+
+        $powershell_code = @'
+#{powershell_code}
+'@
+        $ps = $null
+
+        try
+        {
+          # http://learn-powershell.net/2012/05/13/using-background-runspaces-instead-of-psjobs-for-better-performance/
+          $ps = [powershell]::create()
+          $ps.Runspace = $runspace
+          [Void]$ps.AddScript($powershell_code)
+
+          $asyncResult = $ps.BeginInvoke()
+
+          if (!$asyncResult.AsyncWaitHandle.WaitOne(#{timeout_ms}, $false))
+          {
+            throw "Catastrophic failure: PowerShell DSC resource timeout (#{timeout_ms} ms) exceeded while executing"
+          }
+
+          $output = $ps.EndInvoke($asyncResult)
+          Write-Output $output
+        }
+        catch
+        {
+          try
+          {
+            if ($runspace) { $runspace.Dispose() }
+          }
+          finally
+          {
+            $runspace = $null
+          }
+          @{
+            indesiredstate = $false
+            rebootrequired = $false
+            errormessage = $_.Exception.Message
+          } | ConvertTo-Json -Compress
+        }
+        finally
+        {
+          [Void]$event.Set()
+          [Void]$event.Dispose()
+          if ($ps -ne $null) { [Void]$ps.Dispose() }
+        }
+
+        CODE
+
+        out = exec_read_result(code, output_ready_event)
+
+        { :stdout => out }
+      ensure
+        FFI::WIN32.CloseHandle(output_ready_event) if output_ready_event
+      end
+
+      def exit
+        Puppet.debug "PowerShellManager exiting..."
+        @stdin.puts "\nexit\n"
+        @stdin.close
+        @stdout.close
+
+        exit_msg = "PowerShell process did not terminate in reasonable time"
+        begin
+          Timeout.timeout(3) do
+            Puppet.debug "Awaiting PowerShell process termination..."
+            @exit_status = @ps_process.value
+          end
+        rescue Timeout::Error
+        end
+
+        exit_msg = "PowerShell process exited: #{@exit_status}" if @exit_status
+        Puppet.debug(exit_msg)
+        if @ps_process.alive?
+          Puppet.debug("Forcefully terminating PowerShell process.")
+          Process.kill('KILL', @ps_process[:pid])
+        end
+      end
+
+      private
+
+      def self.is_readable?(stream, timeout = 0.5)
+        read_ready = IO.select([stream], [], [], timeout)
+        read_ready && stream == read_ready[0][0]
+      end
+
+      def self.create_event(name, manual_reset = false, initial_state = false)
+        handle = FFI::Pointer::NULL_HANDLE
+
+        FFI::Pointer.from_string_to_wide_string(name) do |name_ptr|
+          handle = CreateEventW(FFI::Pointer::NULL,
+            manual_reset ? 1 : FFI::WIN32_FALSE,
+            initial_state ? 1 : FFI::WIN32_FALSE,
+            name_ptr)
+
+          if handle == FFI::Pointer::NULL_HANDLE
+            msg = "Failed to create new event #{name}"
+            raise Puppet::Util::Windows::Error.new(msg)
+          end
+        end
+
+        handle
+      end
+
+      WAIT_ABANDONED = 0x00000080
+      WAIT_OBJECT_0 = 0x00000000
+      WAIT_TIMEOUT = 0x00000102
+      WAIT_FAILED = 0xFFFFFFFF
+
+      def self.wait_on(wait_object, timeout_ms = 50)
+        wait_result = Puppet::Util::Windows::Process::WaitForSingleObject(
+          wait_object, timeout_ms)
+
+        case wait_result
+        when WAIT_OBJECT_0
+          Puppet.debug "Wait object signaled"
+        when WAIT_TIMEOUT
+          Puppet.debug "Waited #{timeout_ms} milliseconds..."
+        # only applicable to mutexes - should never happen here
+        when WAIT_ABANDONED
+          msg = 'Catastrophic failure: wait object in inconsistent state'
+          raise Puppet::Util::Windows::Error.new(msg)
+        when WAIT_FAILED
+          msg = 'Catastrophic failure: waiting on object to be signaled'
+          raise Puppet::Util::Windows::Error.new(msg)
+        end
+
+        wait_result
+      end
+
+      def write_stdin(input)
+        @stdin.puts(input)
+      rescue => e
+        msg = "Error writing STDIN / reading STDOUT: #{e}"
+        raise Puppet::Util::Windows::Error.new(msg)
+      end
+
+      def drain_stdout
+        output = []
+        while self.class.is_readable?(@stdout, 0.1) do
+          l = @stdout.gets
+          Puppet.debug "#{Time.now} STDOUT> #{l}"
+          output << l
+        end
+        output
+      end
+
+      def read_stdout(output_ready_event, wait_interval_ms = 50)
+        output = []
+        waited = 0
+
+        # drain the pipe while waiting for the event signal
+        while WAIT_TIMEOUT == self.class.wait_on(output_ready_event, wait_interval_ms)
+          output << drain_stdout
+          waited += wait_interval_ms
+        end
+
+        Puppet.debug "Waited #{waited} total milliseconds."
+
+        # once signaled, ensure everything has been drained
+        output << drain_stdout
+
+        output.join('')
+      rescue => e
+        msg = "Error reading STDOUT: #{e}"
+        raise Puppet::Util::Windows::Error.new(msg)
+      end
+
+      def exec_read_result(powershell_code, output_ready_event)
+        write_stdin(powershell_code)
+        read_stdout(output_ready_event)
+      end
+
+      ffi_convention :stdcall
+
+      # https://msdn.microsoft.com/en-us/library/windows/desktop/ms682396(v=vs.85).aspx
+      # HANDLE WINAPI CreateEvent(
+      #   _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
+      #   _In_     BOOL                  bManualReset,
+      #   _In_     BOOL                  bInitialState,
+      #   _In_opt_ LPCTSTR               lpName
+      # );
+      ffi_lib :kernel32
+      attach_function_private :CreateEventW, [:pointer, :win32_bool, :win32_bool, :lpcwstr], :handle
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -13,6 +13,17 @@ module PuppetX
         @@instances[:cmd] ||= PowerShellManager.new(cmd)
       end
 
+      def self.win32console_enabled?
+        @win32console_enabled ||= defined?(Win32) &&
+          defined?(Win32::Console) &&
+          Win32::Console.class == Class
+      end
+
+      def self.supported?
+        @enabled ||= Puppet::Util::Platform.windows? &&
+          !win32console_enabled?
+      end
+
       def initialize(cmd)
         @stdin, @stdout, @ps_process = Open3.popen2(cmd)
 

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -1,12 +1,14 @@
 require 'securerandom'
 require 'open3'
-require 'ffi'
+require 'ffi' if Puppet::Util::Platform.windows?
 
 module PuppetX
   module Dsc
     class PowerShellManager
-      extend Puppet::Util::Windows::String
-      extend FFI::Library
+      if Puppet::Util::Platform.windows?
+        extend Puppet::Util::Windows::String
+        extend FFI::Library
+      end
 
       @@instances = {}
 
@@ -206,17 +208,19 @@ module PuppetX
         read_stdout(output_ready_event)
       end
 
-      ffi_convention :stdcall
+      if Puppet::Util::Platform.windows?
+        ffi_convention :stdcall
 
-      # https://msdn.microsoft.com/en-us/library/windows/desktop/ms682396(v=vs.85).aspx
-      # HANDLE WINAPI CreateEvent(
-      #   _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
-      #   _In_     BOOL                  bManualReset,
-      #   _In_     BOOL                  bInitialState,
-      #   _In_opt_ LPCTSTR               lpName
-      # );
-      ffi_lib :kernel32
-      attach_function_private :CreateEventW, [:pointer, :win32_bool, :win32_bool, :lpcwstr], :handle
+        # https://msdn.microsoft.com/en-us/library/windows/desktop/ms682396(v=vs.85).aspx
+        # HANDLE WINAPI CreateEvent(
+        #   _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
+        #   _In_     BOOL                  bManualReset,
+        #   _In_     BOOL                  bInitialState,
+        #   _In_opt_ LPCTSTR               lpName
+        # );
+        ffi_lib :kernel32
+        attach_function_private :CreateEventW, [:pointer, :win32_bool, :win32_bool, :lpcwstr], :handle
+      end
     end
   end
 end

--- a/lib/puppet_x/templates/invoke_ps_command.erb
+++ b/lib/puppet_x/templates/invoke_ps_command.erb
@@ -68,6 +68,45 @@ function New-XmlResult
 
 #this is a string so we can import into our dynamic PS instance
 $ourFunctions = @'
+function Get-ProcessEnvironmentVariables
+{
+  $processVars = [Environment]::GetEnvironmentVariables('Process').Keys |
+    % -Begin { $h = @{} } -Process { $h.$_ = (Get-Item Env:\$_).Value } -End { $h }
+
+  # eliminate Machine / User vars so that we have only process vars
+  'Machine', 'User' |
+    % { [Environment]::GetEnvironmentVariables($_).GetEnumerator() } |
+    ? { $processVars.ContainsKey($_.Name) -and ($processVars[$_.Name] -eq $_.Value) } |
+    % { $processVars.Remove($_.Name) }
+
+  $processVars.GetEnumerator() | Sort-Object Name
+}
+
+function Reset-ProcessEnvironmentVariables
+{
+  param($processVars)
+
+  # query Machine vars from registry, ensuring expansion EXCEPT for PATH
+  $vars = [Environment]::GetEnvironmentVariables('Machine').GetEnumerator() |
+    % -Begin { $h = @{} } -Process { $v = if ($_.Name -eq 'Path') { $_.Value } else { [Environment]::GetEnvironmentVariable($_.Name, 'Machine') }; $h."$($_.Name)" = $v } -End { $h }
+
+  # query User vars from registry, ensuring expansion EXCEPT for PATH
+  [Environment]::GetEnvironmentVariables('User').GetEnumerator() | % {
+      if ($_.Name -eq 'Path') { $vars[$_.Name] += ';' + $_.Value }
+      else
+      {
+        $value = [Environment]::GetEnvironmentVariable($_.Name, 'User')
+        $vars[$_.Name] = $value
+      }
+    }
+
+  $processVars.GetEnumerator() | % { $vars[$_.Name] = $_.Value }
+
+  Remove-Item -Path Env:\* -ErrorAction SilentlyContinue -WarningAction SilentlyContinue -Recurse -Verbose
+
+  $vars.GetEnumerator() | % { Set-Item -Path "Env:\$($_.Name)" -Value $_.Value -Verbose }
+}
+
 function Reset-ProcessPowerShellVariables
 {
   param($psVariables)
@@ -116,6 +155,10 @@ try
   [Void]$ps.AddScript($ourFunctions)
   $ps.Invoke()
 
+  if(!$environmentVariables){
+    $environmentVariables = $ps.AddCommand('Get-ProcessEnvironmentVariables').Invoke()
+  }
+
   if($PSVersionTable.PSVersion -le [Version]'2.0'){
     if(!$psVariables){
       $psVariables = $ps.AddScript('Get-Variable').Invoke()
@@ -125,6 +168,9 @@ try
     [void]$ps.AddCommand('Reset-ProcessPowerShellVariables').AddParameter('psVariables', $psVariables)
     $ps.Invoke()
   }
+
+  [Void]$ps.AddCommand('Reset-ProcessEnvironmentVariables').AddParameter('processVars', $environmentVariables)
+  $ps.Invoke()
 
   [Void]$ps.AddScript($powershell_code)
   $asyncResult = $ps.BeginInvoke()

--- a/lib/puppet_x/templates/invoke_ps_command.erb
+++ b/lib/puppet_x/templates/invoke_ps_command.erb
@@ -1,31 +1,115 @@
-$event = [Threading.EventWaitHandle]::OpenExisting("<%= output_ready_event_name %>")
-if ($runspace -eq $null)
+$hostSource = @"
+using System;
+using System.Globalization;
+using System.Management.Automation.Host;
+using System.Threading;
+
+public class PuppetPSHost : PSHost
 {
-  $runspace = [RunspaceFactory]::CreateRunspace()
+    private Guid _hostId = Guid.NewGuid();
+    private bool shouldExit;
+    private int exitCode;
+
+    public PuppetPSHost () {}
+
+    public bool ShouldExit { get { return this.shouldExit; } }
+    public int ExitCode { get { return this.exitCode; } }
+    public void ResetExitStatus()
+    {
+      this.exitCode = 0;
+      this.shouldExit = false;
+    }
+
+    public override Guid InstanceId { get { return _hostId; } }
+    public override string Name { get { return "PuppetPSHost"; } }
+    public override Version Version { get { return new Version(1, 0); } }
+    public override PSHostUserInterface UI { get { return null; } }
+    public override CultureInfo CurrentCulture
+    {
+        get { return Thread.CurrentThread.CurrentCulture; }
+    }
+    public override CultureInfo CurrentUICulture
+    {
+        get { return Thread.CurrentThread.CurrentUICulture; }
+    }
+
+    public override void EnterNestedPrompt() { throw new NotImplementedException(); }
+    public override void ExitNestedPrompt() { throw new NotImplementedException(); }
+    public override void NotifyBeginApplication() { return; }
+    public override void NotifyEndApplication() { return; }
+
+    public override void SetShouldExit(int exitCode)
+    {
+      this.shouldExit = true;
+      this.exitCode = exitCode;
+    }
+}
+"@
+
+function New-XmlResult
+{
+  param(
+    [Parameter()]$exitcode,
+    [Parameter()]$output,
+    [Parameter()]$errormessage
+  )
+
+  # we make our own xml because ConvertTo-Xml makes hard to parse xml ruby side
+  # and we need to be sure
+  $xml = [xml]@"
+<ReturnResult>
+  <Property Name='exitcode'>$($exitcode)</Property>
+  <Property Name='errormessage'>$([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([string]$errormessage)))</Property>
+  <Property Name='stdout'>$([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([string]$output)))</Property>
+</ReturnResult>
+"@
+  $xml.OuterXml
+}
+
+Add-Type -TypeDefinition $hostSource -Language CSharp
+
+$event = [System.Threading.EventWaitHandle]::OpenExisting("<%= output_ready_event_name %>")
+
+if ($runspace -eq $null){
+  # CreateDefault2 requires PS3
+  if ([System.Management.Automation.Runspaces.InitialSessionState].GetMethod('CreateDefault2')){
+    $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2()
+  }else{
+    $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
+  }
+
+  $puppetPSHost = New-Object PuppetPSHost
+  $runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($puppetPSHost, $sessionState)
   $runspace.Open()
 }
 
 $powershell_code = @'
 <%= powershell_code %>
 '@
-$ps = $null
 
 try
 {
-  # http://learn-powershell.net/2012/05/13/using-background-runspaces-instead-of-psjobs-for-better-performance/
-  $ps = [powershell]::create()
-  $ps.Runspace = $runspace
-  [Void]$ps.AddScript($powershell_code)
+  $ps = $null
+  $puppetPSHost.ResetExitStatus()
 
+  if ($PSVersionTable.PSVersion -ge [Version]'3.0') {
+    $runspace.ResetRunspaceState()
+  }
+
+  $ps = [System.Management.Automation.PowerShell]::Create()
+  $ps.Runspace = $runspace
+
+  [Void]$ps.AddScript($powershell_code)
   $asyncResult = $ps.BeginInvoke()
 
-  if (!$asyncResult.AsyncWaitHandle.WaitOne(<%= timeout_ms %>, $false))
-  {
-    throw "Catastrophic failure: PowerShell DSC resource timeout (<%= timeout_ms %> ms) exceeded while executing"
+  if (!$asyncResult.AsyncWaitHandle.WaitOne(<%= timeout_ms %>, $false)){
+    throw "Catastrophic failure: PowerShell module timeout (<%= timeout_ms %> ms) exceeded while executing"
   }
 
   $output = $ps.EndInvoke($asyncResult)
-  Write-Output $output
+  $output = $output | Out-String
+
+  New-XmlResult -exitcode $puppetPSHost.Exitcode -output $output -errormessage $null
 }
 catch
 {
@@ -37,16 +121,25 @@ catch
   {
     $runspace = $null
   }
-  @{
-    indesiredstate = $false
-    rebootrequired = $false
-    errormessage = $_.Exception.Message
-  } | ConvertTo-Json -Compress
+  if(($puppetPSHost -ne $null) -and $puppetPSHost.ExitCode){
+    $ec = $puppetPSHost.ExitCode
+  }else{
+    # This is technically not true at this point as we do not
+    # know what exitcode we should return as an unexpected exception
+    # happened and the user did not set an exitcode. Our best guess
+    # is to return 1 so that we ensure Puppet reports this run as an error.
+    $ec = 1
+  }
+  $output = $_.Exception.Message | Out-String
+  New-XmlResult -exitcode $ec -output $null -errormessage $output
 }
 finally
 {
   [Void]$event.Set()
-  [Void]$event.Dispose()
+  [Void]$event.Close()
+  if ($PSVersionTable.CLRVersion.Major -ge 3) {
+    [Void]$event.Dispose()
+  }
   if ($ps -ne $null) { [Void]$ps.Dispose() }
 }
 

--- a/lib/puppet_x/templates/invoke_ps_command.erb
+++ b/lib/puppet_x/templates/invoke_ps_command.erb
@@ -66,6 +66,20 @@ function New-XmlResult
   $xml.OuterXml
 }
 
+#this is a string so we can import into our dynamic PS instance
+$ourFunctions = @'
+function Reset-ProcessPowerShellVariables
+{
+  param($psVariables)
+  $psVariables | %{
+    $tempVar = $_
+    if(-not(Get-Variable -Name $_.Name -ErrorAction SilentlyContinue)){
+      New-Variable -Name $_.Name -Value $_.Value -Description $_.Description -Option $_.Options -Visibility $_.Visibility
+    }
+  }
+}
+'@
+
 Add-Type -TypeDefinition $hostSource -Language CSharp
 
 $event = [System.Threading.EventWaitHandle]::OpenExisting("<%= output_ready_event_name %>")
@@ -98,6 +112,19 @@ try
 
   $ps = [System.Management.Automation.PowerShell]::Create()
   $ps.Runspace = $runspace
+
+  [Void]$ps.AddScript($ourFunctions)
+  $ps.Invoke()
+
+  if($PSVersionTable.PSVersion -le [Version]'2.0'){
+    if(!$psVariables){
+      $psVariables = $ps.AddScript('Get-Variable').Invoke()
+    }
+    [void]$ps.AddScript('Get-Variable -Scope Global | Remove-Variable -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue')
+    $ps.Invoke()
+    [void]$ps.AddCommand('Reset-ProcessPowerShellVariables').AddParameter('psVariables', $psVariables)
+    $ps.Invoke()
+  }
 
   [Void]$ps.AddScript($powershell_code)
   $asyncResult = $ps.BeginInvoke()

--- a/lib/puppet_x/templates/invoke_ps_command.erb
+++ b/lib/puppet_x/templates/invoke_ps_command.erb
@@ -1,0 +1,53 @@
+$event = [Threading.EventWaitHandle]::OpenExisting("<%= output_ready_event_name %>")
+if ($runspace -eq $null)
+{
+  $runspace = [RunspaceFactory]::CreateRunspace()
+  $runspace.Open()
+}
+
+$powershell_code = @'
+<%= powershell_code %>
+'@
+$ps = $null
+
+try
+{
+  # http://learn-powershell.net/2012/05/13/using-background-runspaces-instead-of-psjobs-for-better-performance/
+  $ps = [powershell]::create()
+  $ps.Runspace = $runspace
+  [Void]$ps.AddScript($powershell_code)
+
+  $asyncResult = $ps.BeginInvoke()
+
+  if (!$asyncResult.AsyncWaitHandle.WaitOne(<%= timeout_ms %>, $false))
+  {
+    throw "Catastrophic failure: PowerShell DSC resource timeout (<%= timeout_ms %> ms) exceeded while executing"
+  }
+
+  $output = $ps.EndInvoke($asyncResult)
+  Write-Output $output
+}
+catch
+{
+  try
+  {
+    if ($runspace) { $runspace.Dispose() }
+  }
+  finally
+  {
+    $runspace = $null
+  }
+  @{
+    indesiredstate = $false
+    rebootrequired = $false
+    errormessage = $_.Exception.Message
+  } | ConvertTo-Json -Compress
+}
+finally
+{
+  [Void]$event.Set()
+  [Void]$event.Dispose()
+  if ($ps -ne $null) { [Void]$ps.Dispose() }
+}
+
+# always need a trailing newline to ensure PowerShell parses code

--- a/metadata.json
+++ b/metadata.json
@@ -11,8 +11,6 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003",
-        "Server 2003 R2",
         "Server 2008",
         "Server 2008 R2",
         "Server 2012",

--- a/spec/acceptance/exec_powershell_spec.rb
+++ b/spec/acceptance/exec_powershell_spec.rb
@@ -241,7 +241,7 @@ describe 'powershell provider:' do #, :unless => UNSUPPORTED_PLATFORMS.include?(
     pexception = <<-MANIFEST
       exec{'PowershellException':
         provider  => powershell,
-        command   => 'Write-Error -message "We are writing an error"',
+        command   => 'throw "We are writing an error"',
       }
     MANIFEST
     it_should_behave_like 'should fail', pexception, /We are writing an error/i

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet_x/puppetlabs/powershell_manager' if Puppet::Util::Platform.windows?
+
+module PuppetX
+  module Dsc
+    class PowerShellManager; end
+  end
+end
+
+describe PuppetX::Dsc::PowerShellManager,
+  :if => Puppet::Util::Platform.windows? && !Facter.value(:uses_win32console) do
+
+  let (:manager) {
+    powershell = Puppet::Type.type(:base_dsc).defaultprovider.command(:powershell)
+    powershell_args = Puppet::Type.type(:base_dsc).defaultprovider.powershell_args
+    PuppetX::Dsc::PowerShellManager.instance("#{powershell} #{powershell_args.join(' ')}")
+  }
+
+  describe "when provided powershell commands" do
+    it "should return simple output" do
+      result = manager.execute('write-output foo')[:stdout]
+      expect(result).to eq("foo\n")
+    end
+
+    it "should execute cmdlets" do
+      result = manager.execute('ls')[:stdout]
+      expect(result).not_to eq(nil)
+    end
+
+    it "should execute cmdlets with pipes" do
+      result = manager.execute('Get-Process | ? { $_.PID -ne $PID }')[:stdout]
+      expect(result).not_to eq(nil)
+    end
+
+    it "should execute multi-line" do
+      result = manager.execute(<<-CODE
+$foo = ls
+$count = $foo.count
+$count
+      CODE
+      )[:stdout]
+      expect(result).not_to eq(nil)
+    end
+
+    it "should reuse the same PowerShell process for multiple calls" do
+      first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+      second_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+      expect(first_pid).to eq(second_pid)
+    end
+
+    it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
+      result = manager.execute(<<-CODE
+$bytes_in_k = (1024 * 64) + 1
+[Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | Write-Output
+        CODE
+        )[:stdout]
+      expect(result).not_to eq(nil)
+    end
+
+    it "should return a JSON response with a timeout error if the execution timeout is exceeded" do
+      timeout_ms = 100
+      result = manager.execute('sleep 1', timeout_ms)
+      response = JSON.parse(result[:stdout])
+      msg = /Catastrophic failure\: PowerShell DSC resource timeout \(#{timeout_ms} ms\) exceeded while executing/
+      expect(response['errormessage']).to match(msg)
+    end
+
+    it "should not deadlock and return a valid JSON response given invalid unparseable PowerShell code" do
+      result = manager.execute(<<-CODE
+        {
+
+        CODE
+        )
+
+      response = JSON.parse(result[:stdout])
+      expect(response["errormessage"]).not_to be_empty
+    end
+  end
+
+end

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -1,36 +1,80 @@
 require 'spec_helper'
 require 'puppet/type'
-require 'puppet_x/puppetlabs/powershell_manager' if Puppet::Util::Platform.windows?
+require 'puppet_x/puppetlabs/powershell_manager'
 
 module PuppetX
-  module Dsc
+  module PowerShell
     class PowerShellManager; end
   end
 end
 
-describe PuppetX::Dsc::PowerShellManager,
-  :if => Puppet::Util::Platform.windows? && !Facter.value(:uses_win32console) do
+describe PuppetX::PowerShell::PowerShellManager,
+  :if => Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported? do
 
   let (:manager) {
-    powershell = Puppet::Type.type(:base_dsc).defaultprovider.command(:powershell)
-    powershell_args = Puppet::Type.type(:base_dsc).defaultprovider.powershell_args
-    PuppetX::Dsc::PowerShellManager.instance("#{powershell} #{powershell_args.join(' ')}")
+    provider = Puppet::Type.type(:exec).provider(:powershell)
+    powershell = provider.command(:powershell)
+    powershell_args = provider.powershell_args
+    PuppetX::PowerShell::PowerShellManager.instance("#{powershell} #{powershell_args.join(' ')}")
   }
 
   describe "when provided powershell commands" do
+    it "shows ps version" do
+      result = manager.execute('$psversiontable')
+      puts result[:stdout]
+    end
+
     it "should return simple output" do
-      result = manager.execute('write-output foo')[:stdout]
-      expect(result).to eq("foo\n")
+      result = manager.execute('write-output foo')
+
+      # STDERR is interpolating the newlines thus it's \n instead of the usual Windows \r\n
+      expect(result[:stdout]).to eq("foo\r\n")
+      expect(result[:exitcode]).to eq(0)
+    end
+
+    it "should return the exitcode specified" do
+      result = manager.execute('write-output foo; exit 55')
+
+      # STDERR is interpolating the newlines thus it's \n instead of the usual Windows \r\n
+      expect(result[:stdout]).to eq("foo\r\n")
+      expect(result[:exitcode]).to eq(55)
+    end
+
+    it "should return the exitcode 1 when exception is thrown" do
+      result = manager.execute('throw "foo"')
+
+      expect(result[:stdout]).to eq(nil)
+      expect(result[:exitcode]).to eq(1)
+    end
+
+    it "should collect anything written to stderr" do
+      result = manager.execute('[System.Console]::Error.WriteLine("foo")')
+
+      # STDERR is interpolating the newlines thus it's \n instead of the usual Windows \r\n
+      expect(result[:stderr][0][0]).to eq("foo\n")
+      expect(result[:exitcode]).to eq(0)
+    end
+
+    it "should handle writting to stdout and stderr" do
+      result = manager.execute('ps;[System.Console]::Error.WriteLine("foo")')
+
+      expect(result[:stdout]).not_to eq(nil)
+      expect(result[:stderr]).not_to eq(nil)
+      expect(result[:exitcode]).to eq(0)
     end
 
     it "should execute cmdlets" do
-      result = manager.execute('ls')[:stdout]
-      expect(result).not_to eq(nil)
+      result = manager.execute('ls')
+
+      expect(result[:stdout]).not_to eq(nil)
+      expect(result[:exitcode]).to eq(0)
     end
 
     it "should execute cmdlets with pipes" do
-      result = manager.execute('Get-Process | ? { $_.PID -ne $PID }')[:stdout]
-      expect(result).not_to eq(nil)
+      result = manager.execute('Get-Process | ? { $_.PID -ne $PID }')
+
+      expect(result[:stdout]).not_to eq(nil)
+      expect(result[:exitcode]).to eq(0)
     end
 
     it "should execute multi-line" do
@@ -39,8 +83,10 @@ $foo = ls
 $count = $foo.count
 $count
       CODE
-      )[:stdout]
-      expect(result).not_to eq(nil)
+      )
+
+      expect(result[:stdout]).not_to eq(nil)
+      expect(result[:exitcode]).to eq(0)
     end
 
     it "should reuse the same PowerShell process for multiple calls" do
@@ -55,27 +101,29 @@ $count
 $bytes_in_k = (1024 * 64) + 1
 [Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | Write-Output
         CODE
-        )[:stdout]
-      expect(result).not_to eq(nil)
+        )
+
+      expect(result[:errormessage]).to eq(nil)
+      expect(result[:exitcode]).to eq(0)
+      expect(result[:stdout]).not_to eq(nil)
     end
 
-    it "should return a JSON response with a timeout error if the execution timeout is exceeded" do
+    it "should return a response with a timeout error if the execution timeout is exceeded" do
       timeout_ms = 100
       result = manager.execute('sleep 1', timeout_ms)
-      response = JSON.parse(result[:stdout])
-      msg = /Catastrophic failure\: PowerShell DSC resource timeout \(#{timeout_ms} ms\) exceeded while executing/
-      expect(response['errormessage']).to match(msg)
+      # TODO What is the real message now?
+      msg = /Catastrophic failure\: PowerShell module timeout \(#{timeout_ms} ms\) exceeded while executing\r\n/
+      expect(result[:errormessage]).to match(msg)
     end
 
-    it "should not deadlock and return a valid JSON response given invalid unparseable PowerShell code" do
+    it "should not deadlock and return a valid response given invalid unparseable PowerShell code" do
       result = manager.execute(<<-CODE
         {
 
         CODE
         )
 
-      response = JSON.parse(result[:stdout])
-      expect(response["errormessage"]).not_to be_empty
+      expect(result[:errormessage]).not_to be_empty
     end
   end
 

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -103,6 +103,13 @@ $count
       expect(result[:stdout]).to eq(nil)
     end
 
+    it "should remove env variables between runs" do
+      manager.execute('[Environment]::SetEnvironmentVariable("foo", "bar", "process")')
+      result = manager.execute('Test-Path env:\foo')
+
+      expect(result[:stdout]).to eq("False\r\n")
+    end
+
     it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
       result = manager.execute(<<-CODE
 $bytes_in_k = (1024 * 64) + 1

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -96,6 +96,13 @@ $count
       expect(first_pid).to eq(second_pid)
     end
 
+    it "should remove psvariables between runs" do
+      manager.execute('$foo = "bar"')
+      result = manager.execute('$foo')
+
+      expect(result[:stdout]).to eq(nil)
+    end
+
     it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
       result = manager.execute(<<-CODE
 $bytes_in_k = (1024 * 64) + 1

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/util'
+require 'puppet_x/puppetlabs/powershell_manager'
 
 describe Puppet::Type.type(:exec).provider(:powershell) do
 
@@ -30,6 +31,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
   describe "#run" do
     context "stubbed calls" do
       before :each do
+        PuppetX::PowerShell::PowerShellManager.stubs(:supported?).returns(false)
         Puppet::Provider::Exec.any_instance.stubs(:run)
       end
 


### PR DESCRIPTION
Supercedes #74 

Channeling @jpogran from previous PR:

> This PR is a port of the PowerShell session code from the DSC module. This code includes some significant speed and system utilization improvements.
> 
> In the prior version every call to exec started a brand new PowerShell process for each of the exec modes: command, onlyif and unless. This was costly in both time and system resources as PowerShell takes significant time to intialize and frequent process creations spike cpu on the target system.
> 
> In this version, a single PowerShell process is created that lives not only for all the modes of exec, but also for the entirety of the Puppet run. We still have a one time cost of time and system utilization for
> process creation for the entire run, but gain the ability to run consecutive commands.
> 
> A second improvement to this version is that we directly pass commands to PowerShell through shell redirection, and not through reading a file in like the last version. This avoids any of the parsing errors
> (MODULES-2634) we have seen. This also improves syntax checking, as we now validate the passed in commands using PowerShell itself before the command is run, allowing us to catch errors sooner and report them.
> 
> Backwards compatibility was an important requirement for this PR as well. The same behavior the old way of executing PowerShell must be maintained with this new way. This presented a problem as the long-lived session would keep all variables from Puppet run to Puppet run. Care was taken to reset the environment between runs by resetting both the PowerShell variables and Environment variables to original state each run. This also refreshed the PowerShell and Environment variables, allowing one to set global variables and have them take effect in the next run, just like the old behavior could.
> 
> While care was taken to run on all environments the old version did, we cannot use the new method with ruby 1.9.3. Ruby in this version used win32console, which breaks when stdout is redirected. This breaks the Puppet logging stream and halts the Puppet run. The code will detect if running on ruby 1.9.3 and use the old PowerShell invocation code, which while slower still allows the user to use this module.
> 
> This PR also removes support for Windows 2003, as Puppet itself has ceased support for Windows 2003.