### PR TITLE
(maint) Changed allowed rspec version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 
 group :development do
   gem 'rake',                                :require => false
-  gem 'rspec', '~>3.0.0',                    :require => false
+  gem 'rspec', '~>3.0',                      :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
   gem 'puppet_facts',                        :require => false


### PR DESCRIPTION
 - Rake 11 was recently released with an incompatible change for
   versions of rspec-core < 3.4.4 (released / fixed 3/9/2016). The
   current Gemfile pessimistically versions against rspec 3.0.0, but
   that prevents it from installing a newer version that would require
   the appropriate / compatible version of rspec-core.  Without this
   change rspec-core 3.0.4 gets installed, which prevents rake from
   running.

   Without the change, any fresh bundles across various OSes, including
   CI in TravisCI and AppVeyor will fail to run any rake tasks.

   An alternate solution would limit rake to < 11, but in testing this
   seemed just as valid.