### PR TITLE
(FM-4952) Restrict Rake to ~> 10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 #end
 
 group :development do
-  gem 'rake',                                :require => false
+  gem 'rake', '~>10.1',                      :require => false
   gem 'rspec', '~>3.0',                      :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,10 @@ RSpec.configure do |config|
     config.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
   end
 
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+
   config.after :suite do
     # return to original tmpdir
     ENV['TMPDIR'] = oldtmpdir


### PR DESCRIPTION
Beaker needs a version of Rake less than
11 due to using `last_comment' in
rake_task.rb:62. Reduce the version of Rake
down to the same dependency that Beaker does
as a development dependency.

Paired with Glenn Sarti <glenn.sarti at puppetlabs dot com>