### PR TITLE
(MODULES-2634) Test try/catch in PowerShell provider

### DIFF
--- a/spec/acceptance/exec_powershell_spec.rb
+++ b/spec/acceptance/exec_powershell_spec.rb
@@ -28,6 +28,30 @@ describe 'powershell provider:' do #, :unless => UNSUPPORTED_PLATFORMS.include?(
       apply_manifest(p1, :catch_failures => true, :future_parser => FUTURE_PARSER)
     end
 
+  end
+
+  describe 'should handle a try/catch successfully' do
+
+    powershell_cmd = <<-CMD
+try{
+  'foo';
+  exit 0
+}catch{
+  exit 1
+}
+    CMD
+
+    p1 = <<-MANIFEST
+      exec{'TestPowershell':
+        command  => '#{powershell_cmd}',
+        provider  => powershell,
+      }
+    MANIFEST
+
+    it 'should not error on first run' do
+      apply_manifest(p1, :expect_changes => true, :future_parser => FUTURE_PARSER)
+    end
+
     it 'should be idempotent' do
       expect(apply_manifest(p1, :catch_failures => true, :future_parser => FUTURE_PARSER).exit_code).to be_zero
     end

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -89,6 +89,22 @@ $count
       expect(result[:exitcode]).to eq(0)
     end
 
+    it "should execute code with a try/catch" do
+      result = manager.execute(<<-CODE
+try{
+  $foo = ls
+  $count = $foo.count
+  $count
+}catch{
+  Write-Error "foo"
+}
+      CODE
+      )
+
+      expect(result[:stdout]).not_to eq(nil)
+      expect(result[:exitcode]).to eq(0)
+    end
+
     it "should reuse the same PowerShell process for multiple calls" do
       first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
       second_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]


### PR DESCRIPTION
Due to the changes from MODULES-2962, ticket MODULES-2634 is fixed
as a side effect. Besides the module itself using try/catch semantics
in a templated PS1 file, it supports any kind of syntax or formatting..

This commit adds two tests to ensure that this is the case. One for
integration testing, the other for acceptance.