### PR TITLE
(MODULES-3280) Remove Verbose Environment Variable Handling

### DIFF
--- a/lib/puppet_x/templates/invoke_ps_command.erb
+++ b/lib/puppet_x/templates/invoke_ps_command.erb
@@ -102,9 +102,9 @@ function Reset-ProcessEnvironmentVariables
 
   $processVars.GetEnumerator() | % { $vars[$_.Name] = $_.Value }
 
-  Remove-Item -Path Env:\* -ErrorAction SilentlyContinue -WarningAction SilentlyContinue -Recurse -Verbose
+  Remove-Item -Path Env:\* -ErrorAction SilentlyContinue -WarningAction SilentlyContinue -Recurse
 
-  $vars.GetEnumerator() | % { Set-Item -Path "Env:\$($_.Name)" -Value $_.Value -Verbose }
+  $vars.GetEnumerator() | % { Set-Item -Path "Env:\$($_.Name)" -Value $_.Value }
 }
 
 function Reset-ProcessPowerShellVariables


### PR DESCRIPTION
When the function to reset the Environment Variables for the single
session PowerShell process was added, the Verbose paramater was mistakenly
left on the Remove-Item and Set-Item cmdlets. This causes a Verbose
message to be written every time the provider is executed, polluting the
Puppet Debug stream. This is only an issue when MODULES-3137 is
implemented as it enables logging Verbose statements.

This removes the Verbose parameters.