### PR TITLE
(maint) Update copyright notice with correct authors

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -36,6 +36,8 @@ MAINTAINERS.md:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"
 NOTICE:
   copyright_holders:
+    - name: 'Josh Cooper, original author'
+      begin: 2013
     - name: 'Puppet, Inc.'
       begin: 2013
       end: 'latest'

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,6 @@
 Puppet Module - puppetlabs-powershell
 
+Copyright 2013 Josh Cooper, original author
 Copyright 2013 - 2016 Puppet, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The previous commit (PR #93) ommited the original author, Josh Cooper, from
the copyright information. This commit adds Josh as the original author and
includes the updates from a modulesync.