### PR TITLE
(MODULES-3344) Nano Server Compatibility

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
   end
 
   def self.powershell_args
-    ps_args = ['-NoProfile', '-NonInteractive', '-Sta', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
+    ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
     ps_args << '-' if PuppetX::PowerShell::PowerShellManager.supported?
     ps_args
   end

--- a/lib/puppet_x/templates/invoke_ps_command.erb
+++ b/lib/puppet_x/templates/invoke_ps_command.erb
@@ -175,7 +175,7 @@ try
   [Void]$ps.AddScript($powershell_code)
   $asyncResult = $ps.BeginInvoke()
 
-  if (!$asyncResult.AsyncWaitHandle.WaitOne(<%= timeout_ms %>, $false)){
+  if (!$asyncResult.AsyncWaitHandle.WaitOne(<%= timeout_ms %>)){
     throw "Catastrophic failure: PowerShell module timeout (<%= timeout_ms %> ms) exceeded while executing"
   }
 


### PR DESCRIPTION
- Use the CoreCLR compatible `WaitHandle.WaitOne(timeout)`
- Don't invoke `powershell.exe` with `-Sta`