### PR TITLE
(MODULES-2634) Verify try/catch with PowerShell module

### DIFF
--- a/spec/acceptance/exec_powershell_spec.rb
+++ b/spec/acceptance/exec_powershell_spec.rb
@@ -34,6 +34,31 @@ describe 'powershell provider:' do #, :unless => UNSUPPORTED_PLATFORMS.include?(
 
   end
 
+  describe 'should handle a try/catch successfully' do
+
+    powershell_cmd = <<-CMD
+try{
+ $foo = ls
+ $count = $foo.count
+ $count
+}catch{
+ Write-Error "foo"
+}
+    CMD
+
+    p1 = <<-MANIFEST
+      exec{'TestPowershell':
+        command  => '#{powershell_cmd}',
+        provider  => powershell,
+      }
+    MANIFEST
+
+    it 'should not error' do
+      apply_manifest(p1, :expect_changes => true, :future_parser => FUTURE_PARSER)
+    end
+
+  end
+
   describe 'should run commands that exit session' do
 
     exit_pp = <<-MANIFEST

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -89,6 +89,22 @@ $count
       expect(result[:exitcode]).to eq(0)
     end
 
+   it "should execute code with a try/catch" do
+     result = manager.execute(<<-CODE
+try{
+ $foo = ls
+ $count = $foo.count
+ $count
+}catch{
+ Write-Error "foo"
+}
+     CODE
+     )
+
+     expect(result[:stdout]).not_to eq(nil)
+     expect(result[:exitcode]).to eq(0)
+   end
+
     it "should reuse the same PowerShell process for multiple calls" do
       first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
       second_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]


### PR DESCRIPTION
Due to the changes from MODULES-2962, ticket MODULES-2634 is fixed
as a side effect. Besides the module itself using try/catch semantics
in a templated PS1 file, it supports any kind of syntax or formatting.

This commit adds a unit test and an acceptance test to ensure that this
is the case.