### PR TITLE
(FM-5240) remove conflict between powershell & dsc

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -1,5 +1,5 @@
 require 'puppet/provider/exec'
-require_relative '../../../puppet_x/puppetlabs/powershell_manager'
+require_relative '../../../puppet_x/puppetlabs/ps_manager'
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
   confine :operatingsystem => :windows
@@ -45,16 +45,16 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
 
   def self.powershell_args
     ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
-    ps_args << '-' if PuppetX::PowerShell::PowerShellManager.supported?
+    ps_args << '-' if PuppetX::PowerShell::PSManager.supported?
     ps_args
   end
 
   def ps_manager
-    PuppetX::PowerShell::PowerShellManager.instance("#{command(:powershell)} #{self.class.powershell_args.join(' ')}")
+    PuppetX::PowerShell::PSManager.instance("#{command(:powershell)} #{self.class.powershell_args.join(' ')}")
   end
 
   def run(command, check = false)
-    if !PuppetX::PowerShell::PowerShellManager.supported?
+    if !PuppetX::PowerShell::PSManager.supported?
       self.class.upgrade_message
       write_script(command) do |native_path|
         # Ideally, we could keep a handle open on the temp file in this

--- a/lib/puppet_x/puppetlabs/ps_manager.rb
+++ b/lib/puppet_x/puppetlabs/ps_manager.rb
@@ -6,13 +6,13 @@ require 'ffi' if Puppet::Util::Platform.windows?
 
 module PuppetX
   module PowerShell
-    class PowerShellManager
+    class PSManager
       extend FFI::Library if Puppet::Util::Platform.windows?
 
       @@instances = {}
 
       def self.instance(cmd)
-        @@instances[:cmd] ||= PowerShellManager.new(cmd)
+        @@instances[:cmd] ||= PSManager.new(cmd)
       end
 
       def self.win32console_enabled?
@@ -63,7 +63,7 @@ module PuppetX
       end
 
       def exit
-        Puppet.debug "PowerShellManager exiting..."
+        Puppet.debug "PSManager exiting..."
         @stdin.puts "\nexit\n"
         @stdin.close
         @stdout.close

--- a/spec/integration/puppet_x/puppetlabs/ps_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/ps_manager_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 require 'puppet/type'
-require 'puppet_x/puppetlabs/powershell_manager'
+require 'puppet_x/puppetlabs/ps_manager'
 
 module PuppetX
   module PowerShell
-    class PowerShellManager; end
+    class PSManager; end
   end
 end
 
-describe PuppetX::PowerShell::PowerShellManager,
-  :if => Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported? do
+describe PuppetX::PowerShell::PSManager,
+  :if => Puppet::Util::Platform.windows? && PuppetX::PowerShell::PSManager.supported? do
 
   let (:manager) {
     provider = Puppet::Type.type(:exec).provider(:powershell)
     powershell = provider.command(:powershell)
     powershell_args = provider.powershell_args
-    PuppetX::PowerShell::PowerShellManager.instance("#{powershell} #{powershell_args.join(' ')}")
+    PuppetX::PowerShell::PSManager.instance("#{powershell} #{powershell_args.join(' ')}")
   }
 
   describe "when provided powershell commands" do

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/util'
-require 'puppet_x/puppetlabs/powershell_manager'
+require 'puppet_x/puppetlabs/ps_manager'
 
 describe Puppet::Type.type(:exec).provider(:powershell) do
 
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
   describe "#run" do
     context "stubbed calls" do
       before :each do
-        PuppetX::PowerShell::PowerShellManager.stubs(:supported?).returns(false)
+        PuppetX::PowerShell::PSManager.stubs(:supported?).returns(false)
         Puppet::Provider::Exec.any_instance.stubs(:run)
       end
 
@@ -146,7 +146,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
     it 'does not emit an irrelevant upgrade message when in a non-Windows environment',
       :if => !Puppet.features.microsoft_windows? do
 
-      expect(PuppetX::PowerShell::PowerShellManager.supported?).to eq(false)
+      expect(PuppetX::PowerShell::PSManager.supported?).to eq(false)
 
       # run should never be called on an unsuitable provider
       Puppet::Type::Exec::ProviderPowershell.any_instance.expects(:run).never
@@ -156,28 +156,28 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
       apply_compiled_manifest(manifest)
     end
 
-    it 'does not emit a warning message when PowerShellManager is usable in a Windows environment',
+    it 'does not emit a warning message when PSManager is usable in a Windows environment',
       :if => Puppet.features.microsoft_windows? do
 
-      PuppetX::PowerShell::PowerShellManager.stubs(:win32console_enabled?).returns(false)
+      PuppetX::PowerShell::PSManager.stubs(:win32console_enabled?).returns(false)
 
-      expect(PuppetX::PowerShell::PowerShellManager.supported?).to eq(true)
+      expect(PuppetX::PowerShell::PSManager.supported?).to eq(true)
 
-      # given PowerShellManager is supported, never emit an upgrade message
+      # given PSManager is supported, never emit an upgrade message
       Puppet::Type::Exec::ProviderPowershell.expects(:upgrade_message).never
 
       apply_compiled_manifest(manifest)
     end
 
-    it 'emits a warning message when PowerShellManager cannot be used in a Windows environment',
+    it 'emits a warning message when PSManager cannot be used in a Windows environment',
       :if => Puppet.features.microsoft_windows? do
 
       # pretend we're Ruby 1.9.3 / Puppet 3.x x86
-      PuppetX::PowerShell::PowerShellManager.stubs(:win32console_enabled?).returns(true)
+      PuppetX::PowerShell::PSManager.stubs(:win32console_enabled?).returns(true)
 
-      expect(PuppetX::PowerShell::PowerShellManager.supported?).to eq(false)
+      expect(PuppetX::PowerShell::PSManager.supported?).to eq(false)
 
-      # given PowerShellManager is NOT supported, emit an upgrade message
+      # given PSManager is NOT supported, emit an upgrade message
       Puppet::Type::Exec::ProviderPowershell.expects(:upgrade_message).once
 
       apply_compiled_manifest(manifest)


### PR DESCRIPTION
When the modules are installed in the same environment the
PowerShellManager class gets pluginsynced from both modules. The DSC one
wins always, which means that execs explode on linux nodes.