### PR TITLE
(FM-5240) Prevent powershell_manager DSC conflict

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -1,5 +1,5 @@
 require 'puppet/provider/exec'
-require_relative '../../../puppet_x/puppetlabs/powershell_manager'
+require_relative '../../../puppet_x/puppetlabs/powershell/powershell_manager'
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
   confine :operatingsystem => :windows

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -87,7 +87,7 @@ module PuppetX
       end
 
       def template_path
-        File.expand_path('../../templates', __FILE__)
+        File.expand_path('../../../templates', __FILE__)
       end
 
       def make_ps_code(powershell_code, output_ready_event_name, timeout_ms = 300 * 1000)

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'puppet/type'
-require 'puppet_x/puppetlabs/powershell_manager'
+require 'puppet_x/puppetlabs/powershell/powershell_manager'
 
 module PuppetX
   module PowerShell

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/util'
-require 'puppet_x/puppetlabs/powershell_manager'
+require 'puppet_x/puppetlabs/powershell/powershell_manager'
 
 describe Puppet::Type.type(:exec).provider(:powershell) do
 


### PR DESCRIPTION
 - DSC and PowerShell both used the path of
   lib/puppet_x/puppetlabs/powershell_manager.b for their uniquely
   namespaced PowerShellManager class.

   Unfortunately, while the file was namespaced differently, upon
   extraction, the files would collide / overwrite one another, so
   only the last file extracted would win.