### PR TITLE
(FM-5241) Release Powershell 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##2015-05-24 - Supported Release 2.0.1
+###Bug Fixes
+
+- Updated the powershell manager in this module in order to not conflict with the Powershell Manager in the Puppet DSC module
+
 ##2015-05-17 - Supported Release 2.0.0
 ###Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-powershell",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Puppet Inc",
   "summary": "Adds a new exec provider for executing PowerShell commands.",
   "license": "Apache-2.0",
@@ -16,7 +16,8 @@
         "Server 2012",
         "Server 2012 R2",
         "7",
-        "8"
+        "8",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
This commit prepares the module for release version 2.0.1.  This commit
also adds Windows 10 as a supported platform for the module as it was
omitted in error in the last release.