### PR TITLE
(maint) Fix changelog release dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-##2015-05-24 - Supported Release 2.0.1
+##2016-05-24 - Supported Release 2.0.1
 ###Bug Fixes
 
 - Updated the powershell manager in this module in order to not conflict with the Powershell Manager in the Puppet DSC module
 
-##2015-05-17 - Supported Release 2.0.0
+##2016-05-17 - Supported Release 2.0.0
 ###Summary
 
 Major release with performance improvements


### PR DESCRIPTION
The release dates for v2.0.0 and v2.0.1 had the incorrect date.  This
commit ammends the release date