### PR TITLE
(MODULES-3347) Handle PS Verbose Output in Tests

### DIFF
--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -161,7 +161,7 @@ $bytes_in_k = (1024 * 64) + 1
     it "should collect anything written to verbose stream" do
       result = manager.execute('$VerbosePreference = "Continue";Write-Verbose "Hello"')
 
-      expect(result[:stdout]).to eq("VERBOSE: Hello\r\n")
+      expect(result[:stdout]).to include("VERBOSE: Hello")
       expect(result[:exitcode]).to eq(0)
     end
 


### PR DESCRIPTION
When the PowerShell Informational Output Streams were implemented in
MODULES-3137 tests were added to ensure each output stream produced
the correct text. The Verbose test proved brittle because we forced
$VerbosePreference to Continue, which caused extra verbose messages
to be written because of PowerShell module auto loading.

This fixes the test to look for our text instead of requiring only
our text