### PR TITLE
(maint) Remove require_relative for Ruby 1.8.7

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -1,5 +1,5 @@
 require 'puppet/provider/exec'
-require_relative '../../../puppet_x/puppetlabs/powershell/powershell_manager'
+require File.join(File.dirname(__FILE__), '../../../puppet_x/puppetlabs/powershell/powershell_manager')
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
   confine :operatingsystem => :windows


### PR DESCRIPTION
 - Because this module can be run on Puppet 3.8, which can run on
   the system Ruby of a Linux machine (such as CentOS 6), it's
   possible that the cdoe will be parsed in a Ruby 1.8.7 environment.

   Move to require with a manually constructed path, which is the
   effectively the same thing as require_relative in newer Rubies.