### PR TITLE
(MODULES-2634) Remove unnecessary binary test file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ coverage/
 .*.sw[op]
 .DS_Store
 .rspec
+tmp/
 


### PR DESCRIPTION
A binary test file was committed in error in MODULES-2634.  This commit removes the test file and updates gitignore so that test files in that location (tmp/...) will be ignored in future