### PR TITLE
(MODULES-2634) Fix PS try/catch in puppet 3.X

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
   private
   def write_script(content, &block)
     Tempfile.open(['puppet-powershell', '.ps1']) do |file|
-      file.write(content)
+      file.puts(content)
       file.flush
       yield native_path(file.path)
     end


### PR DESCRIPTION
In this module, if a user using puppet 3.X  uses a try/catch
statement without a newline at the end it will either be entirely
ignored or it will fail. This is an artifact of how we are using
powershell in older puppet versions, i.e. through a file redirection
into the Command parameter to powershell.exe.

If we add a newline to the end of the tempfile that is passed to PS,
we can execute any logic construct in PS. This fix uses `puts` instead
of `write`, which automatically adds a newline to the end of the script
content.