### PR TITLE
(MODULES-2634) PowerShell Module doesn't run template with try/catch

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -99,6 +99,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
   def write_script(content, &block)
     Tempfile.open(['puppet-powershell', '.ps1']) do |file|
       file.puts(content)
+      file.puts()
       file.flush
       yield native_path(file.path)
     end


### PR DESCRIPTION
Previously, the PowerShell module was not correctly executing
code inside of try / catch blocks in a templated script on Windows
2008 R2 x64, PE version 3.2.3.

This commit appends a newline to the manifest, since
PowerShell needs multiple lines to correctly parse it.