### PR TITLE
(MODULES-3565) Change the working directory if specified in the resource 

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -68,7 +68,12 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
         return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
       end
     else
-      result = ps_manager.execute(command)
+      working_dir = resource[:cwd]
+      if (!working_dir.nil?)
+        self.fail "Working directory '#{working_dir}' does not exist" unless File.directory?(working_dir)
+      end
+
+      result = ps_manager.execute(command,nil,working_dir)
 
       stdout      = result[:stdout]
       stderr      = result[:stderr]

--- a/lib/puppet_x/templates/init_ps.ps1.erb
+++ b/lib/puppet_x/templates/init_ps.ps1.erb
@@ -294,6 +294,7 @@ function New-XmlResult
 }
 
 Add-Type -TypeDefinition $hostSource -Language CSharp
+$global:DefaultWorkingDirectory = (Get-Location -PSProvider FileSystem).Path
 
 #this is a string so we can import into our dynamic PS instance
 $global:ourFunctions = @'
@@ -359,7 +360,10 @@ function Invoke-PowerShellUserCode
     $EventName,
 
     [Int]
-    $TimeoutMilliseconds
+    $TimeoutMilliseconds,
+
+    [String]
+    $WorkingDirectory    
   )
 
 
@@ -392,6 +396,12 @@ function Invoke-PowerShellUserCode
     [Void]$ps.AddScript($global:ourFunctions)
     $ps.Invoke()
 
+    if ([string]::IsNullOrEmpty($WorkingDirectory)) {
+      $ps.Runspace.SessionStateProxy.Path.SetLocation($global:DefaultWorkingDirectory)    
+    } else {
+      if (-not (Test-Path -Path $WorkingDirectory)) { Throw "Working directory `"$WorkingDirectory`" does not exist" }
+      $ps.Runspace.SessionStateProxy.Path.SetLocation($WorkingDirectory)
+    }
 
     if(!$global:environmentVariables){
       $ps.Commands.Clear()

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -307,7 +307,7 @@ $bytes_in_k = (1024 * 64) + 1
     it "should handle shell redirection" do
       # the test here is to ensure that this doesn't break. because we merge the streams regardless
       # the opposite of this test shows the same thing
-      result = manager.execute('function test-warning{ ps;write-warning \'foo\' }; test-warning 3>&1')
+      result = manager.execute('function test-error{ ps;write-error \'foo\' }; test-error 2>&1')
 
       expect(result[:stdout]).not_to eq(nil)
       expect(result[:exitcode]).to eq(0)

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -108,6 +108,25 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
     end
   end
 
+  describe 'when specifying a working directory' do
+    describe 'that does not exist' do
+      let(:work_dir)  {
+        if Puppet.features.microsoft_windows?
+          "#{ENV['SYSTEMROOT']}\\some\\directory\\that\\does\\not\\exist"
+        else
+          '/some/directory/that/does/not/exist'
+        end
+      }
+      let(:command)  { 'exit 0' }
+      let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :powershell, :cwd => work_dir) }
+      let(:provider) { described_class.new(resource) }
+
+      it 'emits an error when working directory does not exist' do
+        expect { provider.run(command) }.to raise_error(/Working directory .+ does not exist/) 
+      end
+    end
+  end
+
   describe 'when applying a catalog' do
     let(:manifest) { <<-MANIFEST
       exec { 'PS':


### PR DESCRIPTION
Previously  the cwd resource parameter was not being used during powershell
script execution.  This PR checks to see if the cwd parameter is specified
on the resource and if so, inserts a 'Set-Location' command at the very top of
the powershell script to change the working directory prior to script execution.

The working directory will always default to the current directory of the process
which creates the powershell manager.  The working directory is not modified
across runspaces/

This PR also moved the default execution timeout value to a separate class
function so that the execute function can be invoked correctly i.e. If the
execute method is to be called with a custom working directory, but with a default
timeout.