### PR TITLE
(MODULES-3468) Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#powershell
+# powershell
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview](#overview)
 2. [Module Description - What the module does and why it is useful](#module-description)
@@ -12,20 +12,20 @@
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
-##Overview
+## Overview
 
 This module adds a new exec provider capable of executing PowerShell commands.
 
-##Module Description
+## Module Description
 
 Puppet provides a built-in `exec` type that is capable of executing commands. This module adds a `powershell` provider to the `exec` type,  which enables `exec` parameters, listed below. This module is particularly helpful if you need to run PowerShell commands but don't know the details about how PowerShell is executed, since you can technically run PowerShell commands in Puppet without the module.
 
-##Setup
+## Setup
 
-###Setup Requirements
+### Setup Requirements
 This module requires PowerShell to be installed and the `powershell.exe` to be available in the system PATH.
 
-###Beginning with powershell
+### Beginning with powershell
 
 The powershell module adapts the Puppet [exec](http://docs.puppet.com/references/stable/type.html#exec) resource to run PowerShell commands. To get started, simply install the module and declare 'powershell' in `provider` with the applicable command.
 
@@ -36,7 +36,7 @@ exec { 'RESOURCENAME':
 }
 ~~~
 
-##Usage
+## Usage
 
 When using `exec` resources with the `powershell` provider, the `command` parameter must be single-quoted to prevent Puppet from interpolating `$(..)`.
 
@@ -77,60 +77,62 @@ $obj.Rename("OtherGuest")
 This has the added benefit of not requiring escaping '$' in the PowerShell code. Note that the files need to have DOS linefeeds or they will not work as expected. One tool for converting UNIX linefeeds to DOS linefeeds is [unix2dos](http://freecode.com/projects/dos2unix).
 
 
-##Reference
+## Reference
 
-####Provider
+#### Provider
 * powershell - Adapts the Puppet `exec` resource to run PowerShell commands.
 
-####Parameters
+#### Parameters
 All parameters are optional.
 
-#####`creates`
+##### `creates`
 Specifies the file to look for before running the command. The command will only run if the file doesn't exist. **Note: This parameter will not create a file, it will simpy look for one.** Valid options: A string of the path to the file. Default: Undefined.
 
-#####`cwd`
+##### `cwd`
 Sets the directory from which to run the command. Valid options: A string of the directory path. Default: Undefined.
 
-#####`command`
+##### `command`
 Specifies the actual PowerShell command to execute. Must either be fully qualified or a search path for the command must be provided. Valid options: String. Default: Undefined.
 
-#####`environment`
+##### `environment`
 Sets additional environment variables to set for a command. Valid options: String, or an array of multiple options. Default: Undefined.
 
-#####`logoutput`
+##### `logoutput`
 Defines whether to log command output in addition to logging the exit code. If you specify 'on_failure', it only logs the output when the command has an exit code that does not match any value specified by the `returns` attribute. Valid options: 'true', 'false', and 'on_failure'. Default: 'on_failure'.
 
-#####`onlyif`
+##### `onlyif`
 Runs the exec only if the command returns 0. Valid options: String. Default: Undefined.
 
-#####`path`
+##### `path`
 Specifies the search path used for command execution. Valid options: String of the path, an array, or a semicolon-separated list. Default: Undefined.
 
-#####`refresh`
+##### `refresh`
 Refreshes the command. Valid options: String. Default: Undefined.
 
-#####`refreshonly`
+##### `refreshonly`
 Refreshes the command only when a dependent object is changed. Used with `subscribe` and `notify` [metaparameters](http://docs.puppet.com/references/latest/metaparameter.html). Valid options: 'true', 'false'. Default: 'false'.
 
-#####`returns`
+##### `returns`
 Lists the expected return code(s). An error will be returned if the executed command returns something else. Valid options: An array of acceptable return codes or a single value. Default: 0.
 
-#####`timeout`
+##### `timeout`
 Sets the maximum time in seconds that the command should take. Valid options: Number or string representation of a number. Default: 300.
 
-#####`tries`
+##### `tries`
 Determines the number of times execution of the command should be attempted. Valid options: Number or a string representation of a number. Default: '1'.
 
-#####`try_sleep`
+##### `try_sleep`
 Specifies the time to sleep in seconds between `tries`. Valid options: Number or a string representation of a number. Default: Undefined.
 
-#####`unless`
+##### `unless`
 Runs the `exec`, unless the command returns 0. Valid options: String. Default: Undefined.
 
-##Limitations
+## Limitations
 
- * Only supported on Windows Server 2003 and above, and Windows 7 and above.
+ * Only supported on Windows Server 2008 and above, and Windows 7 and above.
 
-##Development
+ * Only supported on Powershell 2.0 and above.
+
+## Development
 
 Puppet Inc modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve. We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things. For more information, see our [module contribution guide.](https://docs.puppet.com/forge/contributing.html)


### PR DESCRIPTION
This commit
- Adds the minimum powershell version to the Limitations section
- Removes Window 2003 as a supported OS for this module
- Adds a space in the markdown headers between the hash and text.  While this
renders correctly in GitHub and the Puppet Forge some editors and parsers
require a white space.

[ci skip]