### PR TITLE
(DO NOT MERGE) experimental add ruby 23 to appveyor matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ init:
 - 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
 environment:
   matrix:
+  - RUBY_VER: 23-x64
   - PUPPET_GEM_VERSION: ~> 3.0
     RUBY_VER: 193
   - PUPPET_GEM_VERSION: ~> 3.0


### PR DESCRIPTION
This commit adds ruby 23-x64 temporarily to the appveyor test matrix.

Signed-off-by: Moses Mendoza <mendoza.moses@gmail.com>