### PR TITLE
(MODULES-3443) Emit better user code exceptions

### DIFF
--- a/lib/puppet_x/templates/init_ps.ps1.erb
+++ b/lib/puppet_x/templates/init_ps.ps1.erb
@@ -450,7 +450,17 @@ function Invoke-PowerShellUserCode
       throw "Catastrophic failure: PowerShell module timeout ($TimeoutMilliseconds ms) exceeded while executing"
     }
 
-    $ps.EndInvoke($asyncResult)
+    try
+    {
+      $ps.EndInvoke($asyncResult)
+    } catch {
+      if ($_.Exception.InnerException -ne $null)
+      {
+        throw $_.Exception.InnerException
+      } else {
+        throw $_.Exception
+      }
+    }
 
     [Puppet.PuppetPSHostUserInterface]$ui = $global:puppetPSHost.UI
     [string]$text = $ui.Output
@@ -476,7 +486,14 @@ function Invoke-PowerShellUserCode
       # is to return 1 so that we ensure Puppet reports this run as an error.
       $ec = 1
     }
-    $output = $_.Exception.Message | Out-String
+
+    if ($_.Exception.ErrorRecord.InvocationInfo -ne $null)
+    {
+      $output = $_.Exception.Message + "`n`r" + $_.Exception.ErrorRecord.InvocationInfo.PositionMessage
+    } else {
+      $output = $_.Exception.Message | Out-String
+    }
+
     New-XmlResult -exitcode $ec -output $null -errormessage $output
   }
   finally

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -241,6 +241,20 @@ $bytes_in_k = (1024 * 64) + 1
       expect(first_cwd).to eq("#{work_dir}\r\n")
       expect(second_cwd).to eq("#{current_work_dir}\r\n")      
     end    
+
+    it "should not refer to 'EndInvoke' for a simple error" do
+      result = manager.execute('$ErrorActionPreference = "Stop";$test = 1/0')
+
+      expect(result[:exitcode]).to eq(1)
+      expect(result[:errormessage]).not_to match(/EndInvoke/)
+    end
+
+    it "should display line and offset information for a simple error" do
+      result = manager.execute('$ErrorActionPreference = "Stop";$test = 1/0')
+
+      expect(result[:exitcode]).to eq(1)
+      expect(result[:errormessage]).to match(/At line\:1 char\:33/)
+    end
   end
 
   describe "when output is written to a PowerShell Stream" do


### PR DESCRIPTION
Previously any error in a user supplied code block would error with `Exception
calling "EndInvoke" with "1" argument(s): ....` however this is not very useful
and hides required debugging information for users.  This commit:
- Emits the inner exception on user exit code if it exists.  The inner exception
  is what caused the EndInvoke to fail an contains the true reason why an error
  was thrown
- Modifies the error string output to emit the `ErrorRecord.InvocationInfo`
  which contains the line number and offset where the error occure and an
  excerpt of the offending line
- Adds tests to expect correct messages for simple errors