### PR TITLE
(MODULES-3839) Emit better user code parsing exceptions

### DIFF
--- a/lib/puppet_x/templates/init_ps.ps1.erb
+++ b/lib/puppet_x/templates/init_ps.ps1.erb
@@ -453,6 +453,9 @@ function Invoke-PowerShellUserCode
     try
     {
       $ps.EndInvoke($asyncResult)
+    } catch [System.Management.Automation.IncompleteParseException] {
+      # https://msdn.microsoft.com/en-us/library/system.management.automation.incompleteparseexception%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
+      throw $_.Exception.Message
     } catch {
       if ($_.Exception.InnerException -ne $null)
       {

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -18,6 +18,10 @@ describe PuppetX::PowerShell::PowerShellManager,
     PuppetX::PowerShell::PowerShellManager.instance("#{powershell} #{powershell_args.join(' ')}")
   }
 
+  let(:powershell_runtime_error) { '$ErrorActionPreference = "Stop";$test = 1/0' }
+  let(:powershell_parseexception_error) { '$ErrorActionPreference = "Stop";if (1 -badoperator 2) { Exit 1 }' }
+  let(:powershell_incompleteparseexception_error) { '$ErrorActionPreference = "Stop";if (1 -eq 2) {  ' }
+
   describe "when provided powershell commands" do
     it "shows ps version" do
       result = manager.execute('$psversiontable')
@@ -242,18 +246,55 @@ $bytes_in_k = (1024 * 64) + 1
       expect(second_cwd).to eq("#{current_work_dir}\r\n")      
     end    
 
-    it "should not refer to 'EndInvoke' for a simple error" do
-      result = manager.execute('$ErrorActionPreference = "Stop";$test = 1/0')
+    context "with runtime error" do
+      it "should not refer to 'EndInvoke' or 'throw' for a runtime error" do
+        result = manager.execute(powershell_runtime_error)
 
-      expect(result[:exitcode]).to eq(1)
-      expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:errormessage]).not_to match(/throw/)
+      end
+
+      it "should display line and char information for a runtime error" do
+        result = manager.execute(powershell_runtime_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).to match(/At line\:1 char\:33/)
+      end
     end
 
-    it "should display line and offset information for a simple error" do
-      result = manager.execute('$ErrorActionPreference = "Stop";$test = 1/0')
+    context "with ParseException error" do
+      it "should not refer to 'EndInvoke' or 'throw' for a ParseException error" do
+        result = manager.execute(powershell_parseexception_error)
 
-      expect(result[:exitcode]).to eq(1)
-      expect(result[:errormessage]).to match(/At line\:1 char\:33/)
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:errormessage]).not_to match(/throw/)
+      end
+
+      it "should display line and char information for a ParseException error" do
+        result = manager.execute(powershell_parseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).to match(/At line\:1 char\:39/)
+      end
+    end
+
+    context "with IncompleteParseException error" do
+      it "should not refer to 'EndInvoke' or 'throw' for an IncompleteParseException error" do
+        result = manager.execute(powershell_incompleteparseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:errormessage]).not_to match(/throw/)
+      end
+
+      it "should not display line and char information for an IncompleteParseException error" do
+        result = manager.execute(powershell_incompleteparseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/At line\:\d+ char\:\d+/)
+      end
     end
   end
 


### PR DESCRIPTION
Previously in MODULES-3443 the exception handler was updated to display more
meaningful errors however one type of error was not handled correctly.  If
Powershell generated an `IncompleteParseException` error, the message displayed
to the user would suggest that it occured in `throw $_.Exception.InnerException`
in a line and offset that probably didn't exist.  This is because unlike the
`ParseException` type which gives useful information, an
`IncompleteParseException` can not determine where in the script the error
occured.

This commit changes catches the `IncompleteParseException` error an rethrows it
as a simple text error.  This suppresses the `line:xxx char:xx` text from
being shown to the user, while still displaying the root cause of the error.

This commit refactors the tests slightly so that different error types are
exercised; Runtime, ParseException and IncompleteParseException.