### PR TITLE
(MODULES-3875) Improve PowerShellManager resilience to failure

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -203,9 +203,6 @@ Invoke-PowerShellUserCode @params
 
       def write_stdin(input)
         @stdin.puts(input)
-      rescue => e
-        msg = "Error writing STDIN / reading STDOUT: #{e}"
-        raise Puppet::Util::Windows::Error.new(msg)
       end
 
       def drain_pipe(pipe, iterations = 10)
@@ -245,14 +242,14 @@ Invoke-PowerShellUserCode @params
         errors = errors.reject { |e| e.empty? }
 
         return output.join(''), errors
-      rescue => e
-        msg = "Error reading PIPE: #{e}"
-        raise Puppet::Util::Windows::Error.new(msg)
       end
 
       def exec_read_result(powershell_code, output_ready_event)
         write_stdin(powershell_code)
         read_stdout(output_ready_event)
+      rescue => e
+        msg = "Unexpected error with pipe communication"
+        raise e, msg, e.backtrace
       end
 
       if Puppet::Util::Platform.windows?

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -72,10 +72,11 @@ module PuppetX
 
       def exit
         Puppet.debug "PowerShellManager exiting..."
-        @stdin.puts "\nexit\n"
-        @stdin.close
-        @stdout.close
-        @stderr.close
+        # ignore any failure to call exit against PS process
+        @stdin.puts "\nexit\n" if !@stdin.closed? rescue nil
+        @stdin.close if !@stdin.closed?
+        @stdout.close if !@stdout.closed?
+        @stderr.close if !@stderr.closed?
 
         exit_msg = "PowerShell process did not terminate in reasonable time"
         begin

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -12,7 +12,15 @@ module PuppetX
       @@instances = {}
 
       def self.instance(cmd)
-        @@instances[:cmd] ||= PowerShellManager.new(cmd)
+        manager = @@instances[cmd]
+
+        if manager.nil? || !manager.alive?
+          # ignore any errors trying to tear down this unusable instance
+          manager.exit if manager rescue nil
+          @@instances[cmd] = PowerShellManager.new(cmd)
+        end
+
+         @@instances[cmd]
       end
 
       def self.win32console_enabled?
@@ -26,6 +34,7 @@ module PuppetX
       end
 
       def initialize(cmd)
+        @usable = true
         @stdin, @stdout, @stderr, @ps_process = Open3.popen3(cmd)
 
         Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
@@ -41,6 +50,17 @@ module PuppetX
         at_exit { exit }
       end
 
+      def alive?
+        # powershell process running
+        @ps_process.alive? &&
+          # explicitly set during a read / write failure, like broken pipe EPIPE
+          @usable &&
+          # an explicit failure state might not have been hit, but IO may be closed
+          self.class.is_stream_valid?(@stdin) &&
+          self.class.is_stream_valid?(@stdout) &&
+          self.class.is_stream_valid?(@stderr)
+      end
+
       def execute(powershell_code, timeout_ms = nil, working_dir = nil)
         output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
         output_ready_event = self.class.create_event(output_ready_event_name)
@@ -48,6 +68,9 @@ module PuppetX
         code = make_ps_code(powershell_code, output_ready_event_name, timeout_ms, working_dir)
 
         out, err = exec_read_result(code, output_ready_event)
+
+        # an error was caught during execution that has invalidated any results
+        return { :exitcode => -1, :stderr => err } if !@usable && out.nil?
 
         # Powershell adds in newline characters as it tries to wrap output around the display (by default 80 chars).
         # This behavior is expected and cannot be changed, however it corrupts the XML e.g. newlines in the middle of
@@ -140,6 +163,22 @@ Invoke-PowerShellUserCode @params
         read_ready && stream == read_ready[0][0]
       end
 
+      # when a stream has been closed by handle, but Ruby still has a file
+      # descriptor for it, it can be tricky to determine that it's actually dead
+      # the .fileno will still return an int, and calling get_osfhandle against
+      # it returns what the CRT thinks is a valid Windows HANDLE value, but
+      # that may no longer exist
+      def self.is_stream_valid?(stream)
+        # when a stream is closed, its obviously invalid, but Ruby doesn't always know
+        !stream.closed? &&
+        # so calling stat will yield an EBADF when underlying OS handle is bad
+        # as this resolves to a HANDLE and then calls the Windows API
+        !stream.stat.nil?
+      # any exceptions mean the stream is dead
+      rescue
+        false
+      end
+
       # copied directly from Puppet 3.7+ to support Puppet 3.5+
       def self.wide_string(str)
         # ruby (< 2.1) does not respect multibyte terminators, so it is possible
@@ -222,7 +261,12 @@ Invoke-PowerShellUserCode @params
         waited = 0
 
         # drain the pipe while waiting for the event signal
+        # but prevent an infinite loop by validating the process, pipes, etc
         while WAIT_TIMEOUT == self.class.wait_on(output_ready_event, wait_interval_ms)
+          # Ruby will gleefully allow trying to read stdout / stderr that are
+          # no longer connected to a live process, so therefore check the
+          # liveness here and raise the broken pipe error that Ruby would usually
+          raise Errno::EPIPE if !alive?
           # TODO: While this does ensure that both pipes have been
           # drained it can block on either longer than necessary or
           # deadlock waiting for one or the other to finish. The correct
@@ -247,6 +291,16 @@ Invoke-PowerShellUserCode @params
       def exec_read_result(powershell_code, output_ready_event)
         write_stdin(powershell_code)
         read_stdout(output_ready_event)
+      # if any pipes are broken, the manager is totally hosed
+      # bad file descriptors mean closed stream handles
+      rescue Errno::EPIPE, Errno::EBADF => e
+        @usable = false
+        return nil, [[e.inspect, e.backtrace].flatten]
+      # catch closed stream errors specifically
+      rescue IOError => ioerror
+        raise if !ioerror.message.start_with?('closed stream')
+        @usable = false
+        return nil, [[ioerror.inspect, ioerror.backtrace].flatten]
       rescue => e
         msg = "Unexpected error with pipe communication"
         raise e, msg, e.backtrace

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -5,6 +5,28 @@ require 'puppet_x/puppetlabs/powershell/powershell_manager'
 module PuppetX
   module PowerShell
     class PowerShellManager; end
+    if Puppet::Util::Platform.windows?
+      module WindowsAPI
+        require 'ffi'
+        extend FFI::Library
+
+        ffi_convention :stdcall
+
+        # https://msdn.microsoft.com/en-us/library/ks2530z6%28v=VS.100%29.aspx
+        # intptr_t _get_osfhandle(
+        #    int fd
+        # );
+        ffi_lib [FFI::CURRENT_PROCESS, 'msvcrt']
+        attach_function :get_osfhandle, :_get_osfhandle, [:int], :uintptr_t
+
+        # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
+        # BOOL WINAPI CloseHandle(
+        #   _In_  HANDLE hObject
+        # );
+        ffi_lib :kernel32
+        attach_function :CloseHandle, [:uintptr_t], :int32
+      end
+    end
   end
 end
 
@@ -18,20 +40,181 @@ describe PuppetX::PowerShell::PowerShellManager,
     "#{powershell} #{cli_args.join(' ')}"
   }
 
-  let (:manager) {
+  def create_manager
     PuppetX::PowerShell::PowerShellManager.instance(manager_args)
-  }
+  end
+
+  let (:manager) { create_manager() }
 
   describe "when managing the powershell process" do
     describe "the PowerShellManager::instance method" do
       it "should return the same manager instance / process given the same cmd line" do
         first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
-        manager_2 = PuppetX::PowerShell::PowerShellManager.instance(manager_args)
+        manager_2 = create_manager()
         second_pid = manager_2.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
         expect(manager_2).to eq(manager)
         expect(first_pid).to eq(second_pid)
+      end
+
+      def bad_file_descriptor_regex
+        # Ruby can do something like:
+        # <Errno::EBADF: Bad file descriptor>
+        # <Errno::EBADF: Bad file descriptor @ io_fillbuf - fd:10 >
+        @bad_file_descriptor_regex ||= (
+          ebadf = Errno::EBADF.new()
+          '^' + Regexp.escape("\#<#{ebadf.class}: #{ebadf.message}")
+        )
+      end
+
+      # reason can be a single string / regex or an array of them
+      # by default the matches are treated as literal
+      def expect_dead_manager(manager, reason, style = :exact)
+        # additional attempts to use the manager will fail for the given reason
+        result = manager.execute('Write-Host "hi"')
+        expect(result[:exitcode]).to eq(-1)
+
+        if reason.is_a?(String)
+          expect(result[:stderr][0][0]).to eq(reason) if style == :exact
+          expect(result[:stderr][0][0]).to match(reason) if style == :regex
+        elsif reason.is_a?(Array)
+          expect(reason).to include(result[:stderr][0][0]) if style == :exact
+          if style == :regex
+            expect(result[:stderr][0][0]).to satisfy("should match expected error(s): #{reason}") do |msg|
+              reason.any? { |m| msg.match m }
+            end
+          end
+        end
+
+        # and the manager no longer considers itself alive
+        expect(manager.alive?).to eq(false)
+      end
+
+      def expect_different_manager_returned_than(manager, pid)
+        # acquire another manager instance
+        new_manager = create_manager()
+
+        # which should be different than the one passed in
+        expect(new_manager).to_not eq(manager)
+
+        # with a different PID
+        second_pid = new_manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        expect(pid).to_not eq(second_pid)
+      end
+
+      def close_stream(stream, style = :inprocess)
+        if style == :inprocess
+          stream.close
+        else style == :viahandle
+          handle = PuppetX::PowerShell::WindowsAPI.get_osfhandle(stream.fileno)
+          PuppetX::PowerShell::WindowsAPI.CloseHandle(handle)
+        end
+      end
+
+      it "should create a new PowerShell manager host if user code exits the first process" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        exitcode = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Kill()')[:exitcode]
+
+        # when a process gets torn down out from under manager before reading stdout
+        # it catches the error and returns a -1 exitcode
+        expect(exitcode).to eq(-1)
+
+        expect_dead_manager(manager, Errno::EPIPE.new().inspect, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the underlying PowerShell process is killed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # kill the PID from Ruby
+        process = manager.instance_variable_get(:@ps_process)
+        Process.kill('KILL', process.pid)
+
+        expect_dead_manager(manager, Errno::EPIPE.new().inspect, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the input stream is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # closing stdin from the Ruby side tears down the process
+        close_stream(manager.instance_variable_get(:@stdin), :inprocess)
+
+        expect_dead_manager(manager, IOError.new('closed stream').inspect, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the input stream handle is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # call CloseHandle against stdin, therby tearing down the PowerShell process
+        close_stream(manager.instance_variable_get(:@stdin), :viahandle)
+
+        expect_dead_manager(manager, bad_file_descriptor_regex, :regex)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the output stream is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # closing stdout from the Ruby side allows process to run
+        close_stream(manager.instance_variable_get(:@stdout), :inprocess)
+
+        # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
+        msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
+        expect_dead_manager(manager, msgs, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the output stream handle is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # call CloseHandle against stdout, which leaves PowerShell process running
+        close_stream(manager.instance_variable_get(:@stdout), :viahandle)
+
+        # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
+        msgs = [
+          '^' + Regexp.escape(Errno::EPIPE.new().inspect),
+          bad_file_descriptor_regex
+        ]
+        expect_dead_manager(manager, msgs, :regex)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the error stream is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # closing stderr from the Ruby side allows process to run
+        close_stream(manager.instance_variable_get(:@stderr), :inprocess)
+
+        # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
+        msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
+        expect_dead_manager(manager, msgs, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the error stream handle is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # call CloseHandle against stderr, which leaves PowerShell process running
+        close_stream(manager.instance_variable_get(:@stderr), :viahandle)
+
+        # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
+        msgs = [
+          '^' + Regexp.escape(Errno::EPIPE.new().inspect),
+          bad_file_descriptor_regex
+        ]
+        expect_dead_manager(manager, msgs, :regex)
+
+        expect_different_manager_returned_than(manager, first_pid)
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -179,6 +179,19 @@ try {
       expect(result[:stdout]).to eq("False\r\n")
     end
 
+    it "should be able to write more than the 64k default buffer size to the managers pipe without deadlocking the Ruby parent process or breaking the pipe" do
+      # this was tested successfully up to 5MB of text
+      buffer_string_96k = 'a' * ((1024 * 96) + 1)
+      result = manager.execute(<<-CODE
+'#{buffer_string_96k}' | Write-Output
+        CODE
+        )
+
+      expect(result[:errormessage]).to eq(nil)
+      expect(result[:exitcode]).to eq(0)
+      expect(result[:stdout]).to eq("#{buffer_string_96k}\r\n")
+    end
+
     it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
       result = manager.execute(<<-CODE
 $bytes_in_k = (1024 * 64) + 1


### PR DESCRIPTION
- Existing test verified that 64k generated within PowerShell could
   be sent back to Ruby without deadlocking the Ruby parent process.

   Add a new test that originates 64k+ on the Ruby side and ensures
   that the data is properly round-tripped back to Ruby after
   passing it over stdin to PowerShell (which is implemented under
   the hood with popen3 via a named pipe).

- Previously it was possible to call exit against PowerShellManager
   and not have it completely terminate due to attempting to write to
   broken pipes, etc.

   Now verify state prior to attempting to close since Ruby will raise
   an IOError if calling close against an already closed IO instance

   Also ignore any errors raised when trying to 'exit' the instance

- Instead of having write_sdin / drain_pipe contain their own
   exception handlers, unify them under exec_read_result.

   This also correct two errors in how existing errors were raised:

   * The backtrace of the rescued exception was lost
   * The message would often include "Operation successfully completed"
     as the Windows::Error class is intended to be used after failures
     in FFI calls to Win32 APIs, which automatically call GetLastError
     to look up the reason for the API call failure.  However, since
     these errors are not the result of Windows API failures, the return
     value of GetLastErorr is 0 and the message is misleading.

   This will later allow other I/O and Pipe errors to be captured and
   handled in a single location and prevent code duplication.

- This new test documents how the PowerShell provider makes use of
   the PowerShellManager.  Specifically, it uses the .instance
   factory method and provides a command line.

   There were no existing tests that proved that the manager returns
   the same manager instance, bound to the same underlying PowerShell
   process - which more accureately represents how the provider uses
   the PowerShellManager

   These tests will be further expanded with new manager robustness
   code.

- Previously, an error that took out the PowerShell process could
   render the module unable to process any more PS commands - and
   anything else in the Puppet run using the module would fail.

   A simple way to reproduce this is by explicitly calling:

```
   [Diagnostics.Process]::GetCurrentProcess().Kill()
```

   This could also happen if a pipe breaks with EPIPE, or if any of
   the IO streams are closed to a bad file descriptor (EBADF) or a
   more generic IOError.

- Error handling for IO reads / writes is unified under the
   exec_read_result method. All EPIPE errors, IOError 'closed stream'
   and EBADF 'Bad file descriptor' errors are considered non-terminal,
   and simply inform the PowerShellManager that the current instance is
   unusable and the next time PowerShellManager.instance is called that
   a new PowerShell process should be created. It also ensures that the
   exit code from the execution is a -1, with the stderr containing the
   exception text.

- PowerShellManager.instance does this by explicitly calling an alive?
   helper which makes sure the process is running and all the streams
   are open and stat'able (stat was the only Ruby method that would
   generate an error when the underlying file descriptor or handle was
   bad).  When they are not, a new PowerShell process is created and
   this effectively self-heals between command execution.

- alive? is also used when reading the PowerShell stdout / stderr and
   waiting for PowerShell to have signaled that the output is ready.
   If this check is not performed, the PS process can die (as is the
   case with the new tests), prior to signaling the event that Ruby
   is waiting on, which deadlocks Puppet.

- Add a number of nefarious tests that tear down the underlying
   PowerShell process unexpectedly or that close the stdin, stdout or
   stderr streams in unexpected ways. Depending on Ruby version and
   the sequence of events these situations have slightly different
   failure modes which are captured in the tests.