### PR TITLE
(MODULES-3144) Fix race condition draining pipes

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -251,7 +251,7 @@ Invoke-PowerShellUserCode @params
 
         # there's ultimately a bit of a race here
         # read one more time after signal is received
-        read_from_pipe(pipe, 0) { |s| output << s }
+        read_from_pipe(pipe, 0) { |s| output << s } until !self.class.is_readable?(pipe)
         output
       end
 


### PR DESCRIPTION
 - The code as implemented was subtly flawed.  When draining pipes in
   separate threads, reads proceed until PS has signaled that it has
   executed code and written output.

   Code existed to drain the pipe in case that race occurred. However,
   the code only performed a single read with the Ruby IO.gets method,
   which reads until the next newline character.

   The console width is defined as 120 characters, so a block of XML
   written as a result could end up split up / incomplete.

 - Instead, the code should have been reading while the pipe was
   considered readable, ensuring that it reads all remaining data
   after receiving a completion signal.

 - This bug was trivially reproducible on Windows 2008R2 + PS2, but
   not PS5.  With the fix in place, the problem no longer occurs.