### PR TITLE
(MODULES-3443) Modify error test for differences in Powershell version

### DIFF
--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -472,7 +472,7 @@ $bytes_in_k = (1024 * 64) + 1
         result = manager.execute(powershell_runtime_error)
 
         expect(result[:exitcode]).to eq(1)
-        expect(result[:errormessage]).to match(/At line\:1 char\:33/)
+        expect(result[:errormessage]).to match(/At line\:\d+ char\:\d+/)
       end
     end
 
@@ -489,7 +489,7 @@ $bytes_in_k = (1024 * 64) + 1
         result = manager.execute(powershell_parseexception_error)
 
         expect(result[:exitcode]).to eq(1)
-        expect(result[:errormessage]).to match(/At line\:1 char\:39/)
+        expect(result[:errormessage]).to match(/At line\:\d+ char\:\d+/)
       end
     end
 

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -456,8 +456,9 @@ $bytes_in_k = (1024 * 64) + 1
       first_cwd = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
       second_cwd = manager.execute('(Get-Location).Path')[:stdout]
 
-      expect(first_cwd).to eq("#{work_dir}\r\n")
-      expect(second_cwd).to eq("#{current_work_dir}\r\n")
+      # Paths should be case insensitive
+      expect(first_cwd.downcase).to eq("#{work_dir}\r\n".downcase)
+      expect(second_cwd.downcase).to eq("#{current_work_dir}\r\n".downcase)
     end
 
     context "with runtime error" do

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -31,8 +31,9 @@ module PuppetX
 end
 
 describe PuppetX::PowerShell::PowerShellManager,
-  :if => Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported? do
-
+  :if => Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported?,
+  :skip => (Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported? && get_powershell_major_version >= 3) ? false : "Powershell version is less than 3.0 or undetermined" do
+  
   let (:manager_args) {
     provider = Puppet::Type.type(:exec).provider(:powershell)
     powershell = provider.command(:powershell)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,20 @@ if Puppet.features.microsoft_windows?
       puts "#{path} got error #{output}"
     end
   end
+
+  def get_powershell_major_version()
+    provider = Puppet::Type.type(:exec).provider(:powershell)
+    powershell = provider.command(:powershell)
+    
+    begin
+      psversion = `#{powershell} -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command \"$PSVersionTable.PSVersion.Major.ToString()\"`.chomp!.to_i
+      puts "PowerShell major version number is #{psversion}"
+    rescue
+      puts "Unable to determine PowerShell version"
+      psversion = -1    
+    end
+    psversion
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Previously the integration tests for testing error behavior were passing on
Powershell 3+ however the error parsing is different in Powershell 2.0. This
commit modifies the test expectations for a line and char to returned but the
content of the line and char values are ignored.  This means the tests will now
pass on all Powershell versions but still ensure the correct behavior.

Currently the integration tests are failing on PowerShell version 2.0 or less.
This commit adds a helper function to determine the Powershell version without
the Powershell Manager code, and then skips the PowerShell Manager integration
tests if the PowerShell version is 2.0 or less.

Previously the working directory tests would fail if the path differed with casing however under
Windows paths are not case sensitive.  This commit modifies the test by changing
the string comparison to lowercase.