### PR TITLE
(maint) Re-enable PowerShell 2 tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,20 +19,6 @@ if Puppet.features.microsoft_windows?
       puts "#{path} got error #{output}"
     end
   end
-
-  def get_powershell_major_version()
-    provider = Puppet::Type.type(:exec).provider(:powershell)
-    powershell = provider.command(:powershell)
-    
-    begin
-      psversion = `#{powershell} -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command \"$PSVersionTable.PSVersion.Major.ToString()\"`.chomp!.to_i
-      puts "PowerShell major version number is #{psversion}"
-    rescue
-      puts "Unable to determine PowerShell version"
-      psversion = -1    
-    end
-    psversion
-  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
 - In 5072e28 changes were made to exclude PowerShell 2 from running
   integration specs against PowerShellManager.  There are currently
   only 2 failures related to exceeding the Console BufferSize and
   how PowerShell 2 sends the output through PuppetPSHostUserInterface
   that actually need to be marked pending.

   Re-enable the 47 skipped tests under PowerShell 2 and mark the
   other 2 failing tests as pending.