### PR TITLE
(maint) Fix multiline stderr capture

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -81,9 +81,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
       exit_code   = result[:exitcode]
 
       unless stderr.nil?
-        stderr.each do |er|
-          er.each { |e| Puppet.debug "STDERR: #{e.chop}" } unless er.empty?
-        end
+        stderr.each { |e| Puppet.debug "STDERR: #{e.chop}" unless e.empty? }
       end
 
       Puppet.debug "STDERR: #{result[:errormessage]}" unless result[:errormessage].nil?

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -89,7 +89,10 @@ module PuppetX
             (prop.text.nil? ? nil : Base64.decode64(prop.text))
           # if err contains data it must be "real" stderr output
           # which should be appended to what PS has already captured
-          value += err if err && (err != []) && (name == 'stderr')
+          if name == 'stderr'
+            value = value.nil? ? [] : [value]
+            value += err if !err.nil?
+          end
           [name.to_sym, value]
         end
 

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -271,15 +271,24 @@ describe PuppetX::PowerShell::PowerShellManager,
     it "should collect anything written to stderr" do
       result = manager.execute('[System.Console]::Error.WriteLine("foo")')
 
-      expect(result[:stderr]).to eq("foo\r\n")
+      expect(result[:stderr]).to eq(["foo\r\n"])
       expect(result[:exitcode]).to eq(0)
+    end
+
+    it "should collect multiline output written to stderr" do
+      # induce a failure in cmd.exe that emits a multi-iline error message
+      result = manager.execute('cmd.exe /c foo.exe')
+
+      expect(result[:stdout]).to eq(nil)
+      expect(result[:stderr]).to eq(["'foo.exe' is not recognized as an internal or external command,\n","operable program or batch file.\n"])
+      expect(result[:exitcode]).to eq(1)
     end
 
     it "should handle writting to stdout and stderr" do
       result = manager.execute('ps;[System.Console]::Error.WriteLine("foo")')
 
       expect(result[:stdout]).not_to eq(nil)
-      expect(result[:stderr]).to eq("foo\r\n")
+      expect(result[:stderr]).to eq(["foo\r\n"])
       expect(result[:exitcode]).to eq(0)
     end
 

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -393,31 +393,42 @@ try {
       version
     end
 
-    it "should be able to write more than the 64k default buffer size to the managers pipe without deadlocking the Ruby parent process or breaking the pipe" do
-      pending("Powershell version less than 3.0 has different Write-Output behavior") if current_powershell_major_version < 3
+    def output_cmdlet
+      # Write-Output is the default behavior, except on older PS2 where the
+      # behavior of Write-Output introduces newlines after every width number
+      # of characters as specified in the BufferSize of the custom console UI
+      # Write-Host should usually be avoided, but works for this test in old PS2
+      current_powershell_major_version >= 3 ?
+        'Write-Output' :
+        'Write-Host'
+    end
 
+    it "should be able to write more than the 64k default buffer size to the managers pipe without deadlocking the Ruby parent process or breaking the pipe" do
       # this was tested successfully up to 5MB of text
       buffer_string_96k = 'a' * ((1024 * 96) + 1)
       result = manager.execute(<<-CODE
-'#{buffer_string_96k}' | Write-Output
+'#{buffer_string_96k}' | #{output_cmdlet}
         CODE
         )
 
       expect(result[:errormessage]).to eq(nil)
       expect(result[:exitcode]).to eq(0)
-      expect(result[:stdout]).to eq("#{buffer_string_96k}\r\n")
+      terminator = output_cmdlet == 'Write-Output' ? "\r\n" : "\n"
+      expect(result[:stdout]).to eq("#{buffer_string_96k}#{terminator}")
     end
 
     it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
       result = manager.execute(<<-CODE
 $bytes_in_k = (1024 * 64) + 1
-[Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | Write-Output
+[Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | #{output_cmdlet}
         CODE
         )
 
       expect(result[:errormessage]).to eq(nil)
       expect(result[:exitcode]).to eq(0)
-      expect(result[:stdout]).not_to eq(nil)
+      terminator = output_cmdlet == 'Write-Output' ? "\r\n" : "\n"
+      expected = "\x0" * (1024 * 64 + 1) + terminator
+      expect(result[:stdout]).to eq(expected)
     end
 
     it "should return a response with a timeout error if the execution timeout is exceeded" do


### PR DESCRIPTION
 - Previous code made two bad assumption that could result in the
   module crashing when anything is written to the stderr stream via
   native executables.

   The first assumption is that there is a non-nil value passed back in
   the XML response `stderr` element.  It's completely valid to have no
   pre-existing value present.

   The second assumption was that the captured stderr was a bare string.
   It will never be a bare string and should always be a single element
   string array at the very least.

 - Adjust the code to handle these situations accordingly and introduce
   a new test that creates multiline stderr output.