### PR TITLE
(MODULES-3690) PowerShell v2 + .NET Framework less than 3.5 is unsupported for PowerShell Manager

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -1,4 +1,5 @@
 require 'puppet/provider/exec'
+require File.join(File.dirname(__FILE__), '../../../puppet_x/puppetlabs/powershell/compatible_powershell_version')
 require File.join(File.dirname(__FILE__), '../../../puppet_x/puppetlabs/powershell/powershell_manager')
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
@@ -27,15 +28,26 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
   EOT
 
   POWERSHELL_UPGRADE_MSG = <<-UPGRADE
-  The current Puppet version is outdated and uses a library that was
-  previously necessary on the current Ruby verison to support a colored console.
+  Currently, the PowerShell module has reduced v1 functionality on this agent
+  due to one or more of the following conditions:
 
-  Unfortunately this library prevents the PowerShell module from using a shared
-  PowerShell process to dramatically improve the performance of resource
-  application.
+  - Puppet 3.x (non-x64 version)
+
+    Puppet 3.x uses a Ruby version that requires a library to support a colored
+    console. Unfortunately this library prevents the PowerShell module from
+    using a shared PowerShell process to dramatically improve the performance of
+    resource application.
+
+  - PowerShell v2 with .NET Framework 2.0
+
+    PowerShell v2 works with both .NET Framework 2.0 and .NET Framework 3.5.
+    To be able to use the enhancements, we require at least .NET Framework 3.5.
+    Typically you will only see this on a base Windows Server 2008 (and R2)
+    install.
 
   To enable these improvements, it is suggested to upgrade to any x64 version of
-  Puppet (including 3.x), or to a Puppet version newer than 3.x.
+  Puppet (including 3.x), or to a Puppet version newer than 3.x and ensure you
+  have at least .NET Framework 3.5 installed.
   UPGRADE
 
   def self.upgrade_message

--- a/lib/puppet_x/puppetlabs/powershell/compatible_powershell_version.rb
+++ b/lib/puppet_x/puppetlabs/powershell/compatible_powershell_version.rb
@@ -1,0 +1,51 @@
+require File.join(File.dirname(__FILE__), 'powershell_version')
+
+module PuppetX
+  module PuppetLabs
+    module PowerShell
+      class CompatiblePowerShellVersion
+        def self.compatible_version?
+          value = false
+
+          powershell_version = PuppetX::PuppetLabs::PowerShell::PowerShellVersion.version
+
+          return false if powershell_version.nil?
+
+          # PowerShell v1 - definitely not good to go. Really the entire module
+          # may not even work but I digress
+          return false if Gem::Version.new(powershell_version) < Gem::Version.new(2)
+
+          # PowerShell v3+, we are good to go b/c .NET 4+
+          # https://msdn.microsoft.com/en-us/powershell/scripting/setup/windows-powershell-system-requirements
+          # Look at Microsoft .NET Framwork Requirements section.
+          if Gem::Version.new(powershell_version) >= Gem::Version.new(3)
+            return true
+          end
+
+          # If we are using PowerShell v2, we need to see what the latest
+          # version of .NET is that we have
+          # https://msdn.microsoft.com/en-us/library/hh925568.aspx
+          if Puppet::Util::Platform.windows?
+            require 'win32/registry'
+
+            begin
+              # At this point in the check, PowerShell is using .NET Framework
+              # 2.x family, so we only need to verify v3.5 key exists.
+              # If we were verifying all compatible types we would look for
+              # any of these keys: v3.5, v4.0, v4
+              hive = Win32::Registry::HKEY_LOCAL_MACHINE
+              # redirection doesn't actually matter here - disable it anyway
+              hive.open('SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5', Win32::Registry::KEY_READ | 0x100) do |reg|
+                value = true
+              end
+            rescue Win32::Registry::Error => e
+              value = false
+            end
+          end
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -2,6 +2,7 @@ require 'rexml/document'
 require 'securerandom'
 require 'open3'
 require 'base64'
+require File.join(File.dirname(__FILE__), 'compatible_powershell_version')
 
 module PuppetX
   module PowerShell
@@ -27,8 +28,14 @@ module PuppetX
           Win32::Console.class == Class
       end
 
+      def self.compatible_version_of_powershell?
+        @compatible_powershell_version ||= PuppetX::PuppetLabs::PowerShell::CompatiblePowerShellVersion.compatible_version?
+      end
+
       def self.supported?
-        Puppet::Util::Platform.windows? && !win32console_enabled?
+        Puppet::Util::Platform.windows? &&
+        compatible_version_of_powershell? &&
+        !win32console_enabled?
       end
 
       def initialize(cmd, debug)

--- a/lib/puppet_x/puppetlabs/powershell/powershell_version.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_version.rb
@@ -1,0 +1,53 @@
+module PuppetX
+  module PuppetLabs
+    module PowerShell
+      class PowerShellVersion
+      end
+    end
+  end
+end
+
+if Puppet::Util::Platform.windows?
+  require 'win32/registry'
+  module PuppetX
+    module PuppetLabs
+      module PowerShell
+        class PowerShellVersion
+          ACCESS_TYPE       = Win32::Registry::KEY_READ | 0x100
+          HKLM              = Win32::Registry::HKEY_LOCAL_MACHINE
+          PS_ONE_REG_PATH   = 'SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine'
+          PS_THREE_REG_PATH = 'SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine'
+          REG_KEY           = 'PowerShellVersion'
+
+          def self.version
+            powershell_three_version || powershell_one_version
+          end
+
+          def self.powershell_one_version
+            version     = nil
+            begin
+              HKLM.open(PS_ONE_REG_PATH, ACCESS_TYPE) do |reg|
+                version = reg[REG_KEY]
+              end
+            rescue
+              version = nil
+            end
+            version
+          end
+
+          def self.powershell_three_version
+            version     = nil
+            begin
+              HKLM.open(PS_THREE_REG_PATH, ACCESS_TYPE) do |reg|
+                version = reg[REG_KEY]
+              end
+            rescue
+              version = nil
+            end
+            version
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet_x/puppetlabs/powershell/compatible_powershell_version_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/powershell/compatible_powershell_version_spec.rb
@@ -1,0 +1,58 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet_x/puppetlabs/powershell/powershell_version'
+require 'puppet_x/puppetlabs/powershell/compatible_powershell_version'
+
+describe PuppetX::PuppetLabs::PowerShell::CompatiblePowerShellVersion, :if => Puppet::Util::Platform.windows? do
+  before(:each) do
+    @compat = PuppetX::PuppetLabs::PowerShell::CompatiblePowerShellVersion
+  end
+
+  describe "when a newer version of PowerShell is installed" do
+    it "should return true when PowerShell v3 is installed" do
+      PuppetX::PuppetLabs::PowerShell::PowerShellVersion.expects(:version).returns('3.0')
+
+      expect(@compat.compatible_version?).to eq(true)
+    end
+
+     it "should return true when PowerShell v5.0 is installed" do
+      PuppetX::PuppetLabs::PowerShell::PowerShellVersion.expects(:version).returns('5.0.201001.1')
+
+      expect(@compat.compatible_version?).to eq(true)
+    end
+  end
+
+  describe "when PowerShell v2 is installed" do
+    before(:each) do
+      PuppetX::PuppetLabs::PowerShell::PowerShellVersion.expects(:version).returns('2.0')
+    end
+
+    it "should return true when .NET 3.5 is installed" do
+      reg_key = mock('bob')
+      Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5', Win32::Registry::KEY_READ | 0x100).yields(reg_key)
+
+      expect(@compat.compatible_version?).to eq(true)
+    end
+
+    it "should return false when .NET 3.5 is not installed" do
+      Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+
+      expect(@compat.compatible_version?).to eq(false)
+    end
+  end
+
+  describe "when PowerShell is not installed or not compatible" do
+    it "should return false when PowerShell is not installed" do
+      PuppetX::PuppetLabs::PowerShell::PowerShellVersion.expects(:version).returns(nil)
+
+      expect(@compat.compatible_version?).to eq(false)
+    end
+
+    it "should return false when PowerShell is v1" do
+      PuppetX::PuppetLabs::PowerShell::PowerShellVersion.expects(:version).returns('1.0')
+
+      expect(@compat.compatible_version?).to eq(false)
+    end
+  end
+end

--- a/spec/unit/puppet_x/puppetlabs/powershell/powershell_version_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/powershell/powershell_version_spec.rb
@@ -1,0 +1,75 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet_x/puppetlabs/powershell/powershell_version'
+
+describe PuppetX::PuppetLabs::PowerShell::PowerShellVersion, :if => Puppet::Util::Platform.windows? do
+  before(:each) do
+    @ps = PuppetX::PuppetLabs::PowerShell::PowerShellVersion
+  end
+
+  describe "when powershell is installed" do
+
+    describe "when powershell version is greater than three" do
+
+      it "should detect a powershell version" do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+
+        version = @ps.version
+
+        expect(version).to eq '5.0.10514.6'
+      end
+
+      it "should call the powershell three registry path" do
+        reg_key = mock('bob')
+        reg_key.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).yields(reg_key).once
+
+        @ps.version
+      end
+
+      it "should not call powershell one registry path" do
+        reg_key = mock('bob')
+        reg_key.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).yields(reg_key)
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).times(0)
+
+        @ps.version
+      end
+    end
+
+    describe "when powershell version is less than three" do
+
+      it "should detect a powershell version" do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('2.0')
+
+        version = @ps.version
+
+        expect(version).to eq '2.0'
+      end
+
+      it "should call powershell one registry path" do
+        reg_key = mock('bob')
+        reg_key.expects(:[]).with('PowerShellVersion').returns('2.0')
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).yields(reg_key).once
+
+        version = @ps.version
+
+        expect(version).to eq '2.0'
+      end
+    end
+  end
+
+  describe "when powershell is not installed" do
+
+    it "should return nil and not throw" do
+      Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+      Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+
+      version = @ps.version
+
+      expect(version).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
Determine if the PowerShell version installed is compatible with module. When folks are using PowerShell 3+, they are on .NET Framework 4+, so they are completely compatible with the PowerShell Manager. When folks are using PowerShell v2 and .NET 3.5, they are also compatible, as `System.IO.Pipes` requires at least .NET Framework 3.5.

However if they are running PowerShell v2 with .NET 2.0 (which is not going to happen very often, but it represents a base install on Windows Server 2008 and R2), it is not compatible with the PowerShell Manager. Ensure it switches back to v1 functionality.

Note:
This brings the ability to detect the PowerShell version over from the PowerShell DSC module. I adjusted it to use `PuppetX::PuppetLabs::PowerShell::PowerShellVersion` instead of just `PuppetX::PuppetLabs::PowerShellVersion` like the DSC module to be more proper and avoid conflicts.
