### PR TITLE
Fixes Powershell (1.0) not executing on Windows Server 2016 Standard

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
         # we redirect powershell's stdin to read from the file. Current
         # versions of Windows use per-user temp directories with strong
         # permissions, but I'd rather not make (poor) assumptions.
-        return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
+        return super("\"#{native_path(command(:powershell))}\" #{legacy_args} -Command \"Get-Content \\\"#{native_path}\\\" | Invoke-Expression\"")
       end
     else
       working_dir = resource[:cwd]


### PR DESCRIPTION
Powershell module does not work on Windows Server 2016 Standard (Windows 10.0). This pull request makes the necessary "changes" to restore functionality and is backwards compatible with Windows Server 2012 R2 Standard.