### PR TITLE
(MODULES-4754) Dispose runspace on pipe close

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -108,6 +108,11 @@ module PuppetX
         @usable = false
 
         Puppet.debug "PowerShellManager exiting..."
+
+        # ask PowerShell pipe server to shutdown if its still running
+        # rather than expecting the pipe.close to terminate it
+        write_pipe(pipe_command(:exit)) if !@pipe.closed? rescue nil
+
         # pipe may still be open, but if stdout / stderr are dead PS process is in trouble
         # and will block forever on a write to the pipe
         # its safer to close pipe on Ruby side, which gracefully shuts down PS side

--- a/lib/puppet_x/templates/init_ps.ps1
+++ b/lib/puppet_x/templates/init_ps.ps1
@@ -780,8 +780,18 @@ function Start-PipeServer
   }
   finally
   {
-    if ($server -ne $null) { $server.Dispose() }
+    if ($global:runspace -ne $null)
+    {
+      $global:runspace.Dispose()
+      Write-SystemDebugMessage -Message "PowerShell Runspace Disposed`n`n$_"
+    }
+    if ($server -ne $null)
+    {
+      $server.Dispose()
+      Write-SystemDebugMessage -Message "NamedPipeServerStream Disposed`n`n$_"
+    }
   }
 }
 
 Start-PipeServer -CommandChannelPipeName $NamedPipeName -Encoding $Encoding
+Write-SystemDebugMessage -Message "Start-PipeServer Finished`n`n$_"


### PR DESCRIPTION
 - In the finally block of the Start-PipeServer listener, explicitly
   Dispose of the current loaded PowerShell runspace.