### PR TITLE
(MODULES-4976) Remove rspec configuration for win32_console

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,12 +26,6 @@ RSpec.configure do |config|
   oldtmpdir = Dir.tmpdir()
   ENV['TMPDIR'] = tmpdir
 
-  if Puppet::Util::Platform.windows?
-    config.output_stream = $stdout
-    config.error_stream = $stderr
-    config.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
-  end
-
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
   end


### PR DESCRIPTION
Previously the spec_helper would configure rspec to output all to STDOUT due to
issues with the win32_console gem.  However as that gem was removed in Puppet 4,
it is no longer required.  Also by redirecting to stdout, when using the junit
formatter, the output is sent to STDOUT instead of the specificed text file.
This commit removes the redundant rspec configuration.