### PR TITLE
(MODULES-4138) Provider will respect the environment parameter

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -93,8 +93,9 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
           self.fail "Working directory '#{working_dir}' does not exist" unless File.directory?(working_dir)
         end
         timeout_ms = resource[:timeout].nil? ? nil : resource[:timeout] * 1000
+        environment_variables = resource[:environment].nil? ? [] : resource[:environment]
 
-        result = ps_manager.execute(command,timeout_ms,working_dir)
+        result = ps_manager.execute(command,timeout_ms,working_dir, environment_variables)
 
         stdout      = result[:stdout]
         native_out  = result[:native_stdout]

--- a/lib/puppet_x/templates/init_ps.ps1
+++ b/lib/puppet_x/templates/init_ps.ps1
@@ -389,7 +389,10 @@ function Invoke-PowerShellUserCode
     $TimeoutMilliseconds,
 
     [String]
-    $WorkingDirectory
+    $WorkingDirectory,
+
+    [Hashtable]
+    $ExecEnvironmentVariables
   )
 
   if ($global:runspace -eq $null){
@@ -449,6 +452,11 @@ function Invoke-PowerShellUserCode
     $ps.Commands.Clear()
     [Void]$ps.AddCommand('Reset-ProcessEnvironmentVariables').AddParameter('processVars', $global:environmentVariables)
     $ps.Invoke()
+
+    # Set any exec level environment variables
+    if ($ExecEnvironmentVariables -ne $null) {
+      $ExecEnvironmentVariables.GetEnumerator() | % { Set-Item -Path "Env:\$($_.Name)" -Value $_.Value }
+    }
 
     # we clear the commands before each new command
     # to avoid command pollution

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -454,6 +454,31 @@ try {
       expect(result[:stdout]).to eq("False\r\n")
     end
 
+    it "should set custom environment variables" do
+      result = manager.execute('Write-Output $ENV:foo',nil,nil,['foo=bar'])
+
+      expect(result[:stdout]).to eq("bar\r\n")
+    end
+
+    it "should remove custom environment variables between runs" do
+      manager.execute('Write-Output $ENV:foo',nil,nil,['foo=bar'])
+      result = manager.execute('Write-Output $ENV:foo',nil,nil,[])
+
+      expect(result[:stdout]).to be nil
+    end
+
+    it "should ignore malformed custom environment variable" do
+      result = manager.execute('Write-Output $ENV:foo',nil,nil,['=foo','foo','foo='])
+
+      expect(result[:stdout]).to be nil
+    end
+
+    it "should use last definition for duplicate custom environment variable" do
+      result = manager.execute('Write-Output $ENV:foo',nil,nil,['foo=one','foo=two','foo=three'])
+
+      expect(result[:stdout]).to eq("three\r\n")
+    end
+
     def current_powershell_major_version
       provider = Puppet::Type.type(:exec).provider(:powershell)
       powershell = provider.command(:powershell)


### PR DESCRIPTION
Previously the PowerShell 2.x provider did not use the environment parameter
from the exec Puppet Type.  This commit updates the PowerShell manager to
include custom environment variables passed from the Puppet Resource and
integration tests for this behaviour.