### PR TITLE
(maint) Update date in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2016-11-17 - Supported Release 2.1.1
+## 2017-07-07 - Supported Release 2.1.1
 
 ### Summary
 


### PR DESCRIPTION
This commit fixes the typo in the date of the 2.1.1 release.