### PR TITLE
(MODULES-6081) Rename PowerShell executable

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -8,12 +8,8 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
       "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
     elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
       "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
-    elsif File.exists?('/usr/bin/powershell')
-      '/usr/bin/powershell'
-    elsif File.exists?('/usr/local/bin/powershell')
-      '/usr/local/bin/powershell'
     elsif !Puppet::Util::Platform.windows?
-      "powershell"
+      'pwsh'
     else
       'powershell.exe'
     end

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -31,12 +31,8 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
       "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
     elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
       "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
-    elsif File.exists?('/usr/bin/powershell')
-      '/usr/bin/powershell'
-    elsif File.exists?('/usr/local/bin/powershell')
-      '/usr/local/bin/powershell'
     elsif !Puppet::Util::Platform.windows?
-      "powershell"
+      'pwsh'
     else
       'powershell.exe'
     end


### PR DESCRIPTION
This commit renames the PowerShell binary name from PowerShell to
pwsh. This is because the name of the binary has changed in the
latest PowerShell betas.

