### PR TITLE
(MODULES-4748) Increase timeout for opening PowerShell

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -54,8 +54,8 @@ module PuppetX
         pipe_path = "\\\\.\\pipe\\#{named_pipe_name}"
         # wait for the pipe server to signal ready, and fail if no response in 10 seconds
 
-        # wait up to 10 seconds in 0.2 second intervals to be able to open the pipe
-        50.times do
+        # wait up to 30 seconds in 0.2 second intervals to be able to open the pipe
+        150.times do
           begin
             # pipe is opened in binary mode and must always
             @pipe = File.open(pipe_path, 'r+b')


### PR DESCRIPTION
Prior to this commit, the timeout waiting for PowerShell to start
was only 10 seconds; this was not, in practice, a long enough
period of time for multiple customers, especially when a node is
under heavy load. This commit increases the timeout to 30 seconds.