### PR TITLE
(MODULES-7011) Fix .NET upgrade message

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -41,13 +41,13 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
   - PowerShell v2 with .NET Framework 2.0
 
     PowerShell v2 works with both .NET Framework 2.0 and .NET Framework 3.5.
-    To be able to use the enhancements, we require at least .NET Framework 3.5.
+    To be able to use the enhancements, we require .NET Framework 3.5.
     Typically you will only see this on a base Windows Server 2008 (and R2)
     install.
 
   To enable these improvements, it is suggested to upgrade to any x64 version of
   Puppet (including 3.x), or to a Puppet version newer than 3.x and ensure you
-  have at least .NET Framework 3.5 installed.
+  have .NET Framework 3.5 installed.
   UPGRADE
 
   def self.upgrade_message


### PR DESCRIPTION
When using this module with PowerShell 2.0, the only way to use the
enhanced commonication method is to have .NET 3.5 installed.

The warning message a user received however implied that if you
installed any version higher than 3.5, such as .NET 4.0, that the
message should go away, and receiving it was a bug in the check logic,
which was testing specifically for .NET 3.5 and not >= 3.5.

Unfortunately, our testing confirmed that installing .NET 4.0 on a
machine is not enough to enable the enhanced features in the module.
Having .NET 4 installed does not automatically enable PowerShell 2 to
load the newer asseblies or use the more advanced features in that
version of the CLR. Specific steps must be taken to enable that to
happen, such as editing registry keys, or writing a
powershell.exe.config to the disk. The results of doing this are also
unpredictable.

The change in this commit updates the upgrade message returned to the
user to make it clearer that when using PowerShell 2, the only way to
enable the enhanced features is to install .NET 3.5, not 3.5+.