### PR TITLE
(MODULES-7018) Fix Zero Timeout Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Lists the expected return code(s). If the executed command returns something els
 
 ##### `timeout`
 
-Sets the maximum time in seconds that the command should take. Valid options: Number or string representation of a number. Default: 300.
+Sets the maximum time in seconds that the command should take. Valid options: Number or string representation of a number. Default: 300. A value of `0` for this property will result in using the default timeout of 300. Inifinite timeout is not supported in this module, but large timeouts are allowed if needed.
 
 ##### `tries`
 

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -144,7 +144,15 @@ module PuppetX
 
       def make_ps_code(powershell_code, timeout_ms = nil, working_dir = nil, environment_variables = [])
         begin
+
+          # Zero timeout is a special case. Other modules sometimes treat this
+          # as an infinite timeout. We don't support infinite, so for the case
+          # of a user specifying zero, we sub in the default value of 300
+          # seconds.
+          if (timeout_ms == 0) then timeout_ms = 300 * 1000 end
+
           timeout_ms = Integer(timeout_ms)
+
           # Lower bound protection. The polling resolution is only 50ms
           if (timeout_ms < 50) then timeout_ms = 50 end
         rescue

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -570,6 +570,26 @@ $bytes_in_k = (1024 * 64) + 1
       expect(result[:stdout]).to end_with("404 Craig Not Found\r\n    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException\r\n    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException\r\n \r\n")
     end
 
+    it "should use a default timeout of 300 seconds if the user specified a timeout of 0" do
+      timeout_ms = 0
+      command = 'return $true'
+      code = manager.make_ps_code(command, timeout_ms)
+      expect(code).to match(/TimeoutMilliseconds = 300000/)
+    end
+
+    it "Should use the correct correct timeout if a small value is specified" do
+
+      # Zero timeout is not supported, and a timeout less than 50ms is not supported.
+      # This test is to ensure that the code that inserts the default timeout when 
+      # the user specified zero, does not interfere with the other default of 50ms
+      # if the user specifies a value less than that.
+
+      timeout_ms = 20
+      command = 'return $true'
+      code = manager.make_ps_code(command, timeout_ms)
+      expect(code).to match(/TimeoutMilliseconds = 50/)
+    end
+
     it "should not deadlock and return a valid response given invalid unparseable PowerShell code" do
       result = manager.execute(<<-CODE
         {


### PR DESCRIPTION
Some other Puppet Exec providers will treat a `timeout` value of `0` as
an infinite timeout. We have chosen not to support an infinite timeout
in this provider, so this change will ensure that a sensible value is
used if the user passes in `0` as the timeout. It also fixes the README
documentation to make it clearer that `0` is not supported, and that
attempting to use it will result in the default timeout of 300 seconds
being used instead.