### PR TITLE
Fix issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,18 +197,7 @@ Runs the `exec`, unless the command returns 0. Valid options: String. Default: U
 
 * Experimental support added for Ubuntu 16.04, Ubuntu 14.0.4 and, CentOS 7.
 
-  Note that this module will not install PowerShell on these platforms. For further information see the [Linux installation instructions](https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md).
-
-  Note that on non-Windows platforms the `HOME` environment variable is not available and can cause PowerShell to raise a `The type initializer for 'System.Management.Automation.ConfigPropertyAccessor' threw an exception.` error. This is documented in PowerShell [GitHub Issue 1794](https://github.com/PowerShell/PowerShell/issues/1794). To workaround this issue, add an environment variable parameter to the `Exec` resource which specifies the `HOME` environment variable. For example:
-
-  ``` puppet
-  exec { "CreateTestFile":
-    command     => "'puppet' | Set-Content -Path '/tmp/puppet-test'",
-    unless      => 'If (Test-Path -Path "/tmp/puppet-test") { exit 0 } else { exit 1}',
-    environment => [ 'HOME=/home/username'],
-    provider    => powershell,
-  }
-  ```
+  Note that this module will not install PowerShell on these platforms. For further information see the [Linux installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux).
 
 * Only supported on Powershell 2.0 and above.
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,7 @@ Runs the `exec`, unless the command returns 0. Valid options: String. Default: U
 
 * Only supported on Windows Server 2008 and above, and Windows 7 and above.
 
-* Experimental support added for Ubuntu 16.04, Ubuntu 14.0.4 and, CentOS 7.
-
-  Note that this module will not install PowerShell on these platforms. For further information see the [Linux installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux).
+* Experimental support added for Ubuntu 16.04, Ubuntu 14.0.4 and, CentOS 7. Note that this module will not install PowerShell on these platforms. For further information see the [Linux installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux).
 
 * Only supported on Powershell 2.0 and above.
 


### PR DESCRIPTION
MODULES-8285
The README.md is out of date due to external changes and needs an update. 
First, the link for the Linux installation documentation is dead (404). Substitute a correct link. 
Second, the outside issue with a missing HOME environment variable was closed in 2016. Remove that section of the README.