### PR TITLE
(MODULES-8355) Add pwsh provider

### DIFF
--- a/lib/puppet/provider/exec/pwsh.rb
+++ b/lib/puppet/provider/exec/pwsh.rb
@@ -1,0 +1,70 @@
+require 'puppet/provider/exec'
+
+Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
+  confine :operatingsystem  => [ :windows ]
+
+  commands :pwsh =>
+    if File.exists?("#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe")
+      "#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe"
+    elsif File.exists?("#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe")
+      "#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe"
+    else
+      'pwsh.exe'
+    end
+
+  desc <<-EOT
+    Executes PowerShell Core commands. One of the `onlyif`, `unless`, or `creates`
+    parameters should be specified to ensure the command is idempotent.
+
+    Example:
+        # Rename the Guest account
+        exec { 'rename-guest':
+          command   => '$(Get-CIMInstance Win32_UserAccount -Filter "Name=\'guest\'").Rename("new-guest")',
+          unless    => 'if (Get-CIMInstance Win32_UserAccount -Filter "Name=\'guest\'") { exit 1 }',
+          provider  => pwsh,
+        }
+  EOT
+
+  def run(command, check = false)
+    write_script(command) do |native_path|
+      # Ideally, we could keep a handle open on the temp file in this
+      # process (to prevent TOCTOU attacks), and execute powershell
+      # with -File <path>. But powershell complains that it can't open
+      # the file for exclusive access. If we close the handle, then an
+      # attacker could modify the file before we invoke powershell. So
+      # we redirect powershell's stdin to read from the file. Current
+      # versions of Windows use per-user temp directories with strong
+      # permissions, but I'd rather not make (poor) assumptions.
+      return super("cmd.exe /c \"\"#{native_path(command(:pwsh))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
+    end
+  end
+
+  def checkexe(command)
+  end
+
+  def validatecmd(command)
+    true
+  end
+
+  private
+  def write_script(content, &block)
+    Tempfile.open(['puppet-pwsh', '.ps1']) do |file|
+      file.puts(content)
+      file.puts()
+      file.flush
+      yield native_path(file.path)
+    end
+  end
+
+  def native_path(path)
+    if Puppet::Util::Platform.windows?
+      path.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+    else
+      path
+    end
+  end
+
+  def legacy_args
+    '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass'
+  end
+end

--- a/spec/acceptance/exec_pwsh_spec.rb
+++ b/spec/acceptance/exec_pwsh_spec.rb
@@ -1,0 +1,552 @@
+require 'spec_helper_acceptance'
+
+describe 'powershell provider:' do
+
+  powershell6_agents = hosts_as('powershell6')
+  posix6_agents      = powershell6_agents.select { |a| a.platform =~ /^(?!windows).*$/ }
+  windows6_agents    = powershell6_agents.select { |a| a.platform =~ /^windows.*$/ }
+
+  # Due to https://github.com/PowerShell/PowerShell/issues/1794 the HOME directory must be passed in the environment explicitly
+  # In this case, it just needs a HOME that has a valid directory, no files get stored there
+  # HOME is not used on Windows so it is safe to apply hosts, no matter its platform
+  let (:ps_environment) { "environment => ['HOME=/tmp']," }
+  ps_environment = "environment => ['HOME=/tmp'],"
+
+  def windows_platform?(host)
+    !((host.platform =~ /^windows.*$/).nil?)
+  end
+
+  def platform_string(host, windows, posix)
+    if windows_platform?(host)
+      windows
+    else
+      posix
+    end
+  end
+
+  shared_examples 'should fail' do |manifest, error_check|
+    it 'should throw an error' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each do |hut|
+        result = execute_manifest_on(hut, manifest, :expect_failures => true)
+        unless error_check.nil?
+          expect(result.stderr).to match(error_check)
+        end
+      end
+    end
+  end
+
+  shared_examples 'apply success' do |manifest|
+    it 'should succeed' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, manifest, :catch_failures => true) }
+    end
+  end
+
+  shared_examples 'standard exec' do |powershell_cmd, host_list|
+    padmin = <<-MANIFEST
+      exec{'no fail test':
+        command  => '#{powershell_cmd}',
+        #{ps_environment}
+        provider => pwsh,
+      }
+    MANIFEST
+    it 'should not fail' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      host_list.each { |hut| execute_manifest_on(hut, padmin, :catch_failures => true) }
+    end
+  end
+
+  describe "should run successfully" do
+    powershell6_agents.each do |host|
+      context "on host with platform #{host.platform}" do
+        let(:manifest) {
+          if windows_platform?(host)
+            <<-MANIFEST
+              exec{'TestPowershell':
+                command   => 'Get-Process > c:/process.txt',
+                unless    => 'if(!(test-path "c:/process.txt")){exit 1}',
+                provider  => pwsh,
+              }
+            MANIFEST
+          else
+            <<-MANIFEST
+              exec{'TestPowershell':
+                command   => 'Get-Process > /process.txt',
+                unless    => 'if(!(test-path "/process.txt")){exit 1}',
+                #{ps_environment}
+                provider  => pwsh,
+              }
+            MANIFEST
+          end
+        }
+
+        it 'should not error on first run' do
+          # Run it twice and test for idempotency
+          execute_manifest_on(host, manifest, :catch_failures => true)
+        end
+
+        it 'should be idempotent' do
+          execute_manifest_on(host, manifest, :catch_chages => true)
+        end
+      end
+    end
+  end
+
+  describe 'should handle a try/catch successfully' do
+    powershell6_agents.each do |host|
+      context "on host with platform #{host.platform}" do
+
+        let(:try_successfile) { platform_string(host,'C:\try_success.txt','/try_success.txt') }
+        let(:try_failfile) { platform_string(host,'C:\try_shouldntexist.txt','/try_shouldntexist.txt') }
+        let(:catch_successfile) { platform_string(host,'C:\catch_success.txt','/catch_success.txt') }
+        let(:catch_failfile) { platform_string(host,'C:\catch_shouldntexist.txt','/catch_shouldntexist.txt') }
+        let(:try_content) { 'try_executed' }
+        let(:catch_content) { 'catch_executed' }
+
+        it 'should demonstrably execute PowerShell code inside a try block' do
+
+          powershell_cmd = <<-CMD
+          try {
+          $foo = @(1, 2, 3).count
+          "#{try_content}" | Out-File -FilePath "#{try_successfile}" -Encoding "ASCII"
+          } catch {
+          "catch_executed" | Out-File -FilePath "#{catch_failfile}" -Encoding "ASCII"
+          }
+          CMD
+
+          p1 = <<-MANIFEST
+          exec{'TestPowershell':
+            command  => '#{powershell_cmd}',
+            #{ps_environment}
+            provider => pwsh,
+          }
+          MANIFEST
+
+          execute_manifest_on(host, p1, :catch_failures => true)
+
+          on(host, platform_string(host,"cmd.exe /c \"type #{try_successfile}\"","cat #{try_successfile}")) do |result|
+            assert_match(/#{try_content}/, result.stdout, "Unexpected result for host '#{host}'")
+          end
+
+          on(host, platform_string(host,"cmd.exe /c \"type #{catch_failfile}\"","cat #{catch_failfile}"), :acceptable_exit_codes => [1]) do |result|
+            if windows_platform?(host)
+              assert_match(/^The system cannot find the file specified\./, result.stderr, "Unexpected file content #{result.stdout} on host '#{host}'")
+            else
+              assert_match(/No such file or directory/, result.stderr, "Unexpected file content #{result.stdout} on host '#{host}'")
+            end
+          end
+        end
+
+        it 'should demonstrably execute PowerShell code inside a catch block' do
+          powershell_cmd = <<-CMD
+          try {
+          throw "execute catch!"
+          "try_executed" | Out-File -FilePath "#{try_failfile}" -Encoding "ASCII"
+          } catch {
+          "#{catch_content}" | Out-File -FilePath "#{catch_successfile}" -Encoding "ASCII"
+          }
+          CMD
+
+          p1 = <<-MANIFEST
+          exec{'TestPowershell':
+            command  => '#{powershell_cmd}',
+            #{ps_environment}
+            provider => pwsh,
+          }
+          MANIFEST
+
+          execute_manifest_on(host, p1, :catch_failures => true)
+
+          on(host, platform_string(host,"cmd.exe /c \"type #{catch_successfile}\"","cat #{catch_successfile}")) do |result|
+            assert_match(/#{catch_content}/, result.stdout, "Unexpected result for host '#{host}'")
+          end
+
+          on(host, platform_string(host,"cmd.exe /c \"type #{try_failfile}\"","cat #{try_failfile}"), :acceptable_exit_codes => [1]) do |result|
+            if windows_platform?(host)
+              assert_match(/^The system cannot find the file specified\./, result.stderr, "Unexpected file content #{result.stdout} on host '#{host}'")
+            else
+              assert_match(/No such file or directory/, result.stderr, "Unexpected file content #{result.stdout} on host '#{host}'")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'should run commands that exit session' do
+
+    let(:exit_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'exit 0',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    it 'should not error on first run' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, exit_pp, :expect_changes => true) }
+    end
+
+    it 'should run a second time' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, exit_pp, :expect_changes => true) }
+    end
+
+  end
+
+  describe 'should run commands that break session' do
+
+    let(:break_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'Break',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    it 'should not error on first run' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, break_pp, :expect_changes => true) }
+    end
+
+    it 'should run a second time' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, break_pp, :expect_changes => true) }
+    end
+
+  end
+
+  describe 'should run commands that return from session' do
+
+    let(:return_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'return 0',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    it 'should not error on first run' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, return_pp, :expect_changes => true) }
+    end
+
+    it 'should run a second time' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, return_pp, :expect_changes => true) }
+    end
+
+  end
+
+  describe 'should not leak variables across calls to single session' do
+
+    let(:var_leak_setup_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => '$special=1',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    let(:var_leak_test_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'if ( $special -eq 1 ) { exit 1 } else { exit 0 }',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    it 'should not see variable from previous run' do
+      # Setup the variable
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, var_leak_setup_pp, :expect_changes => true) }
+
+      # Test to see if subsequent call sees the variable
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, var_leak_test_pp, :expect_changes => true) }
+    end
+
+  end
+
+  describe 'should not leak environment variables across calls to single session' do
+
+    let(:envar_leak_setup_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => "\\$env:superspecial='1'",
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    let(:envar_leak_test_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => "if ( \\$env:superspecial -eq '1' ) { exit 1 } else { exit 0 }",
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    let(:envar_ext_test_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => "if ( \\$env:outside -eq '1' ) { exit 0 } else { exit 1 }",
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    after(:each) do
+      # Due to https://tickets.puppetlabs.com/browse/BKR-1088, need to use different commands
+      powershell6_agents.each do |host|
+        if windows_platform?(host)
+          on(host, powershell("'Remove-Item Env:\\superspecial -ErrorAction Ignore;exit 0'"))
+          on(host, powershell("'Remove-Item Env:\\outside -ErrorAction Ignore;exit 0'"))
+        else
+          on(host, 'unset superspecial')
+          on(host, 'unset outside')
+        end
+      end
+    end
+
+    it 'should not see environment variable from previous run' do
+      # Setup the environment variable
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, envar_leak_setup_pp, :expect_changes => true) }
+
+      # Test to see if subsequent call sees the environment variable
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, envar_leak_test_pp, :expect_changes => true) }
+    end
+
+    it 'should see environment variables set outside of session' do
+      # Setup the environment variable outside of Puppet
+
+      powershell6_agents.each do |host|
+        # Due to https://tickets.puppetlabs.com/browse/BKR-1088, need to use different commands
+        if windows_platform?(host)
+          on(host, powershell("\\$env:outside='1'"))
+        else
+          on(host, 'export outside=1')
+        end
+      end
+
+      # Test to see if initial run sees the environment variable
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, envar_leak_test_pp, :expect_changes => true) }
+
+      # Test to see if subsequent call sees the environment variable and environment purge
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, envar_leak_test_pp, :expect_changes => true) }
+    end
+  end
+
+  describe 'should allow exit from unless' do
+
+    let(:unless_not_triggered_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'exit 0',
+        unless    => 'exit 1',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    let(:unless_triggered_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'exit 0',
+        unless    => 'exit 0',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    it 'should RUN command if unless is NOT triggered' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, unless_not_triggered_pp, :expect_changes => true) }
+    end
+
+    it 'should NOT run command if unless IS triggered' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, unless_triggered_pp, :catch_changes => true) }
+    end
+
+  end
+
+  describe 'should allow exit from onlyif' do
+
+    let(:onlyif_not_triggered_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'exit 0',
+        onlyif    => 'exit 1',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    let(:onlyif_triggered_pp) { <<-MANIFEST
+      exec{'TestPowershell':
+        command   => 'exit 0',
+        onlyif    => 'exit 0',
+        #{ps_environment}
+        provider  => pwsh,
+      }
+    MANIFEST
+    }
+
+    it 'should NOT run command if onlyif is NOT triggered' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, onlyif_not_triggered_pp, :catch_changes => true) }
+    end
+
+    it 'should RUN command if onlyif IS triggered' do
+      # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+      powershell6_agents.each { |hut| execute_manifest_on(hut, onlyif_triggered_pp, :expect_changes => true) }
+    end
+
+  end
+
+  describe 'should be able to access the files after execution' do
+    let(:p2) { <<-MANIFEST
+      exec{"TestPowershell":
+        command   => ' "puppet" | Out-File -FilePath #{file_path} -Encoding UTF8',
+        #{ps_environment}
+        provider  => pwsh
+      }
+    MANIFEST
+    }
+
+    describe file('c:/services.txt'), :if => windows6_agents.count > 0 do
+      let(:file_path) { 'C:/services.txt' }
+
+      it 'should apply the manifest' do
+        # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+        windows6_agents.each { |hut| execute_manifest_on(hut, p2, :catch_failures => true) }
+      end
+
+      it { should be_file }
+      its(:content) { should match /puppet/ }
+    end
+  end
+
+  describe 'should catch and rethrow exceptions up to puppet' do
+    pexception = <<-MANIFEST
+      exec{'PowershellException':
+        provider  => pwsh,
+        #{ps_environment}
+        command   => 'throw "We are writing an error"',
+      }
+    MANIFEST
+    it_should_behave_like 'should fail', pexception, /We are writing an error/i
+  end
+
+  describe 'should error if timeout is exceeded' do
+    ptimeoutexception = <<-MANIFEST
+      exec{'PowershellException':
+        command  => 'Write-Host "Going to sleep now..."; Start-Sleep 5',
+        timeout  => 2,
+        #{ps_environment}
+        provider => pwsh,
+      }
+    MANIFEST
+    it_should_behave_like 'should fail', ptimeoutexception
+  end
+
+  describe 'should be able to execute a ps1 file provided' do
+    context 'on Windows platforms', :if => windows6_agents.count > 0 do
+      p2 = <<-MANIFEST
+      file{'c:/services.ps1':
+        content => '#{File.open(File.join(File.dirname(__FILE__), 'files/services.ps1')).read()}'
+      }
+      exec{"TestPowershellPS1":
+        command   => 'c:/services.ps1',
+        provider  => pwsh,
+        require   => File['c:/services.ps1']
+      }
+      MANIFEST
+      describe file('c:/temp/services.csv') do
+        # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+        windows6_agents.each { |hut| execute_manifest_on(hut, p2, :catch_failures => true) }
+        it { should be_file }
+        its(:content) { should match /puppet/ }
+      end
+    end
+  end
+
+  describe 'passing parameters to the ps1 file' do
+    context 'on Windows platforms', :if => windows6_agents.count > 0 do
+      outfile = 'C:/temp/svchostprocess.txt'
+      processName = 'svchost'
+      pp = <<-MANIFEST
+        $process = '#{processName}'
+        $outFile = '#{outfile}'
+      file{'c:/param_script.ps1':
+        content => '#{File.open(File.join(File.dirname(__FILE__), 'files/param_script.ps1')).read()}'
+      }
+      exec{'run this with param':
+        provider => pwsh,
+        command	 => "c:/param_script.ps1 -ProcessName '$process' -FileOut '$outFile'",
+        require  => File['c:/param_script.ps1'],
+      }
+      MANIFEST
+      describe file(outfile) do
+        # Due to https://tickets.puppetlabs.com/browse/QA-3461 each host must be done one at a time
+        windows6_agents.each { |hut| execute_manifest_on(hut, pp, :catch_failures => true) }
+        it { should be_file }
+        its(:content) { should match /svchost/ }
+      end
+    end
+  end
+
+  describe 'should execute using 64 bit powershell', :if => windows6_agents.count > 0 do
+    # Only applicable to Windows platforms
+    p3 = <<-MANIFEST
+     $maxArchNumber = $::architecture? {
+      /(?i)(i386|i686|x86)$/	=> 4,
+      /(?i)(x64|x86_64)/=> 8,
+      default => 0
+    }
+    exec{'Test64bit':
+      command => "if([IntPtr]::Size -eq $maxArchNumber) { exit 0 } else { Write-Error 'Architecture mismatch' }",
+      #{ps_environment}
+      provider => pwsh
+    }
+    MANIFEST
+    it_should_behave_like 'apply success', p3, windows6_agents
+  end
+
+  describe 'test admin rights', :if => windows6_agents.count > 0 do
+    # Only applicable to Windows platforms
+    ps1 = <<-PS1
+      $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+      $pr = New-Object Security.Principal.WindowsPrincipal $id
+      if(!($pr.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))){Write-Error "Not in admin"}
+    PS1
+    it_should_behave_like 'standard exec', ps1, windows6_agents
+  end
+
+  describe 'test import-module' do
+    pimport = <<-PS1
+      $mods = Get-Module -ListAvailable
+      if($mods.Length -lt 1) {
+        Write-Error "Expected to get at least one module, but none were listed"
+      }
+      Import-Module $mods[0].Name
+      if(-not (Get-Module $mods[0].Name)){
+        Write-Error "Failed to import module ${mods[0].Name}"
+      }
+    PS1
+    it_should_behave_like 'standard exec', pimport, powershell6_agents
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -46,7 +46,11 @@ unless ENV['MODULE_provision'] == 'no'
         on(host,'curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/microsoft.repo')
         on(host,'yum install -y powershell')
       when /^windows/
-        # No need to do anything
+        # Install PowerShell 6 if needed
+        if hosts_as('powershell6').map { |item| item.name }.include?(host.name)
+          on(host,'powershell -NoLogo -NoProfile -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri https://github.com/PowerShell/PowerShell/releases/download/v6.1.1/PowerShell-6.1.1-win-x64.msi -OutFile C:\\PS611.msi -UseBasicParsing"')
+          on(host,'msiexec.exe /i C:\\\\PS611.msi /qn ALLUSERS=1 /l*v C:\\\\PS611-install.log')
+        end
       else
         raise("Unable to install PowerShell on host '#{host.name}' with platform '#{host.platform}'")
       end

--- a/spec/unit/provider/exec/pwsh_spec.rb
+++ b/spec/unit/provider/exec/pwsh_spec.rb
@@ -1,0 +1,150 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util'
+require 'puppet_x/puppetlabs/powershell/powershell_manager'
+require 'fileutils'
+
+describe Puppet::Type.type(:exec).provider(:pwsh), :if => Puppet.features.microsoft_windows? do
+
+  # Override the run value so we can test the super call
+  # There is no real good way to do this otherwise, previously we were
+  # testing Puppet internals that changed in 3.4.0 and made the specs
+  # no longer work the way they were originally specified.
+  Puppet::Type::Exec::ProviderPwsh.instance_eval do
+    alias_method :run_spec_override, :run
+  end
+
+  let(:command)  { '$(Get-CIMInstance Win32_Account -Filter "SID=\'S-1-5-18\'") | Format-List' }
+  let(:args) {
+    if Puppet.features.microsoft_windows?
+      '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command -'
+    else
+      '-NoProfile -NonInteractive -NoLogo -Command -'
+    end
+  }
+  # Due to https://github.com/PowerShell/PowerShell/issues/1794 the HOME directory must be passed in the environment explicitly
+  let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :pwsh, :environment => "HOME=#{ENV['HOME']}" ) }
+  let(:provider) { described_class.new(resource) }
+
+  let(:pwsh) {
+    if File.exists?("#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe")
+      "#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe"
+    elsif File.exists?("#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe")
+      "#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe"
+    else
+      'pwsh.exe'
+    end
+  }
+
+  describe "#run" do
+    context "stubbed calls" do
+      before :each do
+        #PuppetX::PowerShell::PowerShellManager.stubs(:supported?).returns(false)
+        Puppet::Provider::Exec.any_instance.stubs(:run)
+      end
+
+      it "should call exec run" do
+        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
+
+        provider.run_spec_override(command)
+      end
+
+      context "on windows", :if => Puppet.features.microsoft_windows? do
+        it "should call cmd.exe /c" do
+          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
+            .with(regexp_matches(/^cmd.exe \/c/), anything)
+
+          provider.run_spec_override(command)
+        end
+
+        it "should quote the path to the temp file" do
+          path = 'C:\Users\albert\AppData\Local\Temp\puppet-powershell20130715-788-1n66f2j.ps1'
+
+          provider.expects(:write_script).with(command).yields(path)
+          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
+            with(regexp_matches(/^cmd.exe \/c ".* < "#{Regexp.escape(path)}""/), false)
+
+          provider.run_spec_override(command)
+        end
+
+        it "should supply default arguments to supress user interaction" do
+          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
+            with(regexp_matches(/^cmd.exe \/c ".* #{args} < .*"/), false)
+
+          provider.run_spec_override(command)
+        end
+      end
+    end
+
+    context "actual runs" do
+      context "on Windows", :if => Puppet.features.microsoft_windows? do
+        it "returns the output and status" do
+          output, status = provider.run(command)
+
+          expect(output).to match(/SID\s+:\s+S-1-5-18/)
+          expect(status.exitstatus).to eq(0)
+        end
+
+        it "returns true if the `onlyif` check command succeeds" do
+          resource[:onlyif] = command
+
+          expect(resource.parameter(:onlyif).check(command)).to eq(true)
+        end
+
+        it "returns false if the `unless` check command succeeds" do
+          resource[:unless] = command
+
+          expect(resource.parameter(:unless).check(command)).to eq(false)
+        end
+
+        it "runs commands properly that output to multiple streams" do
+          command = 'echo "foo"; [System.Console]::Error.WriteLine("bar"); cmd.exe /c foo.exe'
+          output, status = provider.run(command)
+
+          # when PowerShellManager is not used, the v1 style module collected
+          # all streams inside of a single output string
+          expected = [
+            "foo\n",
+            "bar\n'",
+            "foo.exe' is not recognized as an internal or external command,\n",
+            "operable program or batch file.\n"
+          ].join('')
+
+          expect(output).to eq(expected)
+          expect(status.exitstatus).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe "#checkexe" do
+    it "should skip checking the exe" do
+      expect(provider.checkexe(command)).to be_nil
+    end
+  end
+
+  describe "#validatecmd" do
+    it "should always successfully validate the command to execute" do
+      expect(provider.validatecmd(command)).to eq(true)
+    end
+  end
+
+  describe 'when specifying a working directory' do
+    describe 'that does not exist' do
+      let(:work_dir)  {
+        if Puppet.features.microsoft_windows?
+          "#{ENV['SYSTEMROOT']}\\some\\directory\\that\\does\\not\\exist"
+        else
+          '/some/directory/that/does/not/exist'
+        end
+      }
+      let(:command)  { 'exit 0' }
+      let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :pwsh, :cwd => work_dir) }
+      let(:provider) { described_class.new(resource) }
+
+      it 'emits an error when working directory does not exist' do
+        expect { provider.run(command) }.to raise_error(/Working directory .+ does not exist/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
PowerShell 6 now uses a different binary and has different installation locations
compared to Windows PowerShell.  This commit adds a new provider called pwsh
which will execute scripts but using PowerShell 6 (pwsh).  Later commits will add
advanced features, but this commit adds a basic provider with tests that works
only on Windows, with PowerShell 6 in the default installation location.