### PR TITLE
(MODULES-8357) Add cross platform support for pwsh provider

### DIFF
--- a/spec/acceptance/files/command-to-outfile.ps1
+++ b/spec/acceptance/files/command-to-outfile.ps1
@@ -1,0 +1,7 @@
+Param(
+	[String] $CommandName,
+	[String] $fileOut
+)
+$cmd = Get-Command -Name $CommandName
+New-Item $fileOut -ItemType File
+$cmd | Out-File $fileOut -Encoding ASCII

--- a/spec/acceptance/files/get-command-win.ps1
+++ b/spec/acceptance/files/get-command-win.ps1
@@ -1,0 +1,5 @@
+$temp = "C:\Temp"
+if(!(Test-Path $temp)){
+    mkdir $temp
+}
+Get-Command -Name Get-Command | Export-Csv "$temp/commands.csv" -Encoding "ASCII"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -48,8 +48,8 @@ unless ENV['MODULE_provision'] == 'no'
       when /^windows/
         # Install PowerShell 6 if needed
         if hosts_as('powershell6').map { |item| item.name }.include?(host.name)
-          on(host,'powershell -NoLogo -NoProfile -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri https://github.com/PowerShell/PowerShell/releases/download/v6.1.1/PowerShell-6.1.1-win-x64.msi -OutFile C:\\PS611.msi -UseBasicParsing"')
-          on(host,'msiexec.exe /i C:\\\\PS611.msi /qn ALLUSERS=1 /l*v C:\\\\PS611-install.log')
+          on(host,'powershell -NoLogo -NoProfile -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri https://github.com/PowerShell/PowerShell/releases/download/v6.1.2/PowerShell-6.1.2-win-x64.msi -OutFile C:\\PS612.msi -UseBasicParsing"')
+          on(host,'msiexec.exe /i C:\\\\PS612.msi /qn ALLUSERS=1 /l*v C:\\\\PS612-install.log')
         end
       else
         raise("Unable to install PowerShell on host '#{host.name}' with platform '#{host.platform}'")

--- a/spec/unit/provider/exec/pwsh_spec.rb
+++ b/spec/unit/provider/exec/pwsh_spec.rb
@@ -1,11 +1,9 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/util'
-require 'puppet_x/puppetlabs/powershell/powershell_manager'
 require 'fileutils'
 
-describe Puppet::Type.type(:exec).provider(:pwsh), :if => Puppet.features.microsoft_windows? do
-
+describe Puppet::Type.type(:exec).provider(:pwsh) do
   # Override the run value so we can test the super call
   # There is no real good way to do this otherwise, previously we were
   # testing Puppet internals that changed in 3.4.0 and made the specs
@@ -15,19 +13,15 @@ describe Puppet::Type.type(:exec).provider(:pwsh), :if => Puppet.features.micros
   end
 
   let(:command)  { '$(Get-CIMInstance Win32_Account -Filter "SID=\'S-1-5-18\'") | Format-List' }
-  let(:args) {
-    if Puppet.features.microsoft_windows?
-      '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command -'
-    else
-      '-NoProfile -NonInteractive -NoLogo -Command -'
-    end
-  }
-  # Due to https://github.com/PowerShell/PowerShell/issues/1794 the HOME directory must be passed in the environment explicitly
-  let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :pwsh, :environment => "HOME=#{ENV['HOME']}" ) }
+  let(:args) { '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command -' }
+
+  let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :pwsh) }
   let(:provider) { described_class.new(resource) }
 
   let(:pwsh) {
-    if File.exists?("#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe")
+    if !Puppet::Util::Platform.windows?
+      'pwsh'
+    elsif File.exists?("#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe")
       "#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe"
     elsif File.exists?("#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe")
       "#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe"
@@ -39,9 +33,10 @@ describe Puppet::Type.type(:exec).provider(:pwsh), :if => Puppet.features.micros
   describe "#run" do
     context "stubbed calls" do
       before :each do
-        #PuppetX::PowerShell::PowerShellManager.stubs(:supported?).returns(false)
         Puppet::Provider::Exec.any_instance.stubs(:run)
       end
+
+      let(:shell_command) { Puppet.features.microsoft_windows? ? 'cmd.exe /c' : '/bin/sh -c' }
 
       it "should call exec run" do
         Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
@@ -49,70 +44,73 @@ describe Puppet::Type.type(:exec).provider(:pwsh), :if => Puppet.features.micros
         provider.run_spec_override(command)
       end
 
-      context "on windows", :if => Puppet.features.microsoft_windows? do
-        it "should call cmd.exe /c" do
-          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
-            .with(regexp_matches(/^cmd.exe \/c/), anything)
+      it "should call shell command" do
+        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
+          .with(regexp_matches(/#{shell_command}/), anything)
 
-          provider.run_spec_override(command)
-        end
+        provider.run_spec_override(command)
+      end
 
-        it "should quote the path to the temp file" do
-          path = 'C:\Users\albert\AppData\Local\Temp\puppet-powershell20130715-788-1n66f2j.ps1'
+      it "should quote the path to the temp file", :if => Puppet.features.microsoft_windows? do
+        # Path quoting is only required on Windows
+        path = 'C:\Users\albert\AppData\Local\Temp\puppet-powershell20130715-788-1n66f2j.ps1'
 
-          provider.expects(:write_script).with(command).yields(path)
-          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
-            with(regexp_matches(/^cmd.exe \/c ".* < "#{Regexp.escape(path)}""/), false)
+        provider.expects(:write_script).with(command).yields(path)
+        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
+          with(regexp_matches(/^#{shell_command} .* < "#{Regexp.escape(path)}"/), false)
 
-          provider.run_spec_override(command)
-        end
+        provider.run_spec_override(command)
+      end
 
-        it "should supply default arguments to supress user interaction" do
-          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
-            with(regexp_matches(/^cmd.exe \/c ".* #{args} < .*"/), false)
+      it "should supply default arguments to supress user interaction" do
+        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
+          with(regexp_matches(/^#{shell_command} .* #{args} < .*"/), false)
 
-          provider.run_spec_override(command)
-        end
+        provider.run_spec_override(command)
       end
     end
 
     context "actual runs" do
-      context "on Windows", :if => Puppet.features.microsoft_windows? do
-        it "returns the output and status" do
-          output, status = provider.run(command)
+      # The usage of uname is a little fragile however there is basically nothing
+      # which is universal across all Linux/Unix/Mac distributions; Unlike Well Known SIDS in Windows
+      # The closest is the presence of the uname command and its generic text output
+      let(:command) { Puppet.features.microsoft_windows? ?
+        '$(Get-CIMInstance Win32_Account -Filter "SID=\'S-1-5-18\'") | Format-List' :
+        '& uname' }
+      let(:command_output_regex) { Puppet.features.microsoft_windows? ? /SID\s+:\s+S-1-5-18/ : /(Linux|Darwin)/ }
 
-          expect(output).to match(/SID\s+:\s+S-1-5-18/)
-          expect(status.exitstatus).to eq(0)
-        end
+      it "returns the output and status" do
+        output, status = provider.run(command)
 
-        it "returns true if the `onlyif` check command succeeds" do
-          resource[:onlyif] = command
+        expect(output).to match(command_output_regex)
+        expect(status.exitstatus).to eq(0)
+      end
 
-          expect(resource.parameter(:onlyif).check(command)).to eq(true)
-        end
+      it "returns true if the `onlyif` check command succeeds" do
+        resource[:onlyif] = command
 
-        it "returns false if the `unless` check command succeeds" do
-          resource[:unless] = command
+        expect(resource.parameter(:onlyif).check(command)).to eq(true)
+      end
 
-          expect(resource.parameter(:unless).check(command)).to eq(false)
-        end
+      it "returns false if the `unless` check command succeeds" do
+        resource[:unless] = command
 
-        it "runs commands properly that output to multiple streams" do
-          command = 'echo "foo"; [System.Console]::Error.WriteLine("bar"); cmd.exe /c foo.exe'
-          output, status = provider.run(command)
+        expect(resource.parameter(:unless).check(command)).to eq(false)
+      end
 
-          # when PowerShellManager is not used, the v1 style module collected
-          # all streams inside of a single output string
-          expected = [
-            "foo\n",
-            "bar\n'",
-            "foo.exe' is not recognized as an internal or external command,\n",
-            "operable program or batch file.\n"
-          ].join('')
+      it "runs commands properly that output to multiple streams" do
+        command = Puppet.features.microsoft_windows? ?
+          'echo "foo"; [System.Console]::Error.WriteLine("bar"); cmd.exe /c foo.exe' :
+          'echo "foo"; [System.Console]::Error.WriteLine("bar"); & foo.exe'
+        expected = Puppet.features.microsoft_windows? ?
+          "foo\nbar\n'foo.exe' is not recognized as an internal or external command,\noperable program or batch file.\n" :
+          "^foo\nbar\n.+The term \'foo\.exe\' is not recognized as the name of a cmdlet, function.+"
 
-          expect(output).to eq(expected)
-          expect(status.exitstatus).to eq(1)
-        end
+        output, status = provider.run(command)
+
+        # Due to the different behaviour of uname across non-Windows platforms, must use a regex
+        expect(output).to match(expected)
+        expect(status.exitstatus).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Previously the pwsh provider only functioned on Windows operating systems.

This commit;
* Modifies the provider to not be confined to Windows operating systems
* Modifies the spec tests to be able to run on non-Windows platforms
* Modifies the acceptance tests to be able to run on non-Windows platforms
