### PR TITLE
(MODULES-8356) Search for pwsh binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,25 @@ This module adds a new exec provider capable of executing PowerShell commands.
 
 ## Module Description
 
-Puppet provides a built-in `exec` type that is capable of executing commands. This module adds a `powershell` provider to the `exec` type,  which enables `exec` parameters, listed below. This module is particularly helpful if you need to run PowerShell commands but don't know the details about how PowerShell is executed, because you can run PowerShell commands in Puppet without the module.
+Puppet provides a built-in `exec` type that is capable of executing commands. This module adds a `powershell` and `pwsh` provider to the `exec` type,  which enables `exec` parameters, listed below. This module is particularly helpful if you need to run PowerShell commands but don't know how PowerShell is executed, because you can run PowerShell commands in Puppet without the module.
 
 ## Setup
 
 ### Requirements
 
-This module requires PowerShell to be installed and the `powershell.exe` to be available in the system PATH.
+The `powershell` provider requires [Windows PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-5.1) and have `powershell.exe` available in the system PATH. Note that most Windows operating systems already have Windows PowerShell installed.
+
+The `pwsh` provider requires you install [PowerShell Core](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-6) and make `pwsh` available either in the system PATH or specified in the `path` parameter.
+
+For example, when PowerShell Core is installed in `/usr/alice/pscore` the following manifest is needed:
+
+~~~ puppet
+exec { 'RESOURCENAME':
+  ...
+  path     => '/usr/alice/pscore',
+  provider => pwsh,
+}
+~~~
 
 ### Beginning with powershell
 
@@ -41,7 +53,7 @@ exec { 'RESOURCENAME':
 
 ## Usage
 
-When using `exec` resources with the `powershell` provider, the `command` parameter must be single-quoted to prevent Puppet from interpolating `$(..)`.
+When using `exec` resources with the `powershell` or `pwsh` provider, the `command` parameter must be single-quoted to prevent Puppet from interpolating `$(..)`.
 
 For instance, to rename the Guest account:
 
@@ -129,7 +141,9 @@ However, to produce output from a script, use the `Write-` prefixed cmdlets such
 
 #### Provider
 
-* powershell: Adapts the Puppet `exec` resource to run PowerShell commands.
+* powershell: Adapts the Puppet `exec` resource to run [Windows PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-5.1) commands.
+
+* pwsh: Adapts the Puppet `exec` resource to run [PowerShell Core](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-6) commands.
 
 #### Parameters
 
@@ -163,6 +177,8 @@ Runs the exec only if the command returns 0. Valid options: String. Default: Und
 
 Specifies the search path used for command execution. Valid options: String of the path, an array, or a semicolon-separated list. Default: Undefined.
 
+The `pwsh` provider can also use the path to find the pwsh executable.
+
 ##### `refresh`
 
 Refreshes the command. Valid options: String. Default: Undefined.
@@ -193,11 +209,29 @@ Runs the `exec`, unless the command returns 0. Valid options: String. Default: U
 
 ## Limitations
 
-* Only supported on Windows Server 2008 and above, and Windows 7 and above.
+* The `powershell` provider is only supported on Windows Server 2008 and above, and Windows 7 and above.
 
-* Experimental support added for Ubuntu 16.04, Ubuntu 14.0.4 and, CentOS 7. Note that this module will not install PowerShell on these platforms. For further information see the [Linux installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux).
+* The `pwsh` provider is supported on:
 
-* Only supported on Powershell 2.0 and above.
+  * CentOS 7
+
+  * Debian 8.7+, Debian 9
+
+  * Fedora 27, 28
+
+  * MacOS 10.12+
+
+  * Red Hat Enterprise Linux 7
+
+  * Ubuntu 14.04, 16.0.4 and 18.04
+
+  * Windows Desktop 7 and above
+
+  * Windows Server 2008 R2 and above
+
+  Note that this module will not install PowerShell on these platforms. For further information see the [Linux installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux).
+
+* Only supported on Windows PowerShell 2.0 and above, and PowerShell Core 6.1 and above.
 
 * When using here-strings in inline or templated scripts executed by this module, you must use the double-quote style syntax that begins with `@"` and ends with `"@`. The single-quote syntax that begins with `@'` and ends with `'@` is not supported.
 

--- a/lib/puppet/provider/exec/pwsh.rb
+++ b/lib/puppet/provider/exec/pwsh.rb
@@ -1,17 +1,6 @@
 require 'puppet/provider/exec'
 
 Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
-  commands :pwsh =>
-    if !Puppet::Util::Platform.windows?
-      'pwsh'
-    elsif File.exists?("#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe")
-      "#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe"
-    elsif File.exists?("#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe")
-      "#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe"
-    else
-      'pwsh.exe'
-    end
-
   desc <<-EOT
     Executes PowerShell Core commands. One of the `onlyif`, `unless`, or `creates`
     parameters should be specified to ensure the command is idempotent.
@@ -26,6 +15,8 @@ Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
   EOT
 
   def run(command, check = false)
+    pwsh = get_pwsh_command
+    self.fail 'pwsh could not be found' if pwsh.nil?
     write_script(command) do |native_path|
       # Ideally, we could keep a handle open on the temp file in this
       # process (to prevent TOCTOU attacks), and execute powershell
@@ -36,9 +27,9 @@ Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
       # versions of Windows use per-user temp directories with strong
       # permissions, but I'd rather not make (poor) assumptions.
       if Puppet::Util::Platform.windows?
-        return super("cmd.exe /c \"\"#{native_path(command(:pwsh))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
+        return super("cmd.exe /c \"\"#{native_path(pwsh)}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
       else
-        return super("/bin/sh -c \"#{native_path(command(:pwsh))} #{legacy_args} -Command - < #{native_path}\"", check)
+        return super("/bin/sh -c \"#{native_path(pwsh)} #{legacy_args} -Command - < #{native_path}\"", check)
       end
     end
   end
@@ -51,6 +42,71 @@ Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
   end
 
   private
+
+  def get_pwsh_command
+    if @resource['path'].nil?
+      pwsh = Puppet::Util.which('pwsh')
+    else
+      pwsh = which_with_custom_env('pwsh', @resource['path'])
+    end
+    return pwsh unless pwsh.nil?
+
+    return nil unless Puppet::Util::Platform.windows?
+    # These paths are Windows only
+    pwsh = "#{ENV['ProgramFiles']}\\PowerShell\\6\\pwsh.exe"
+    return pwsh if File.exists?(pwsh)
+    pwsh = "#{ENV['ProgramFiles(x86)']}\\PowerShell\\6\\pwsh.exe"
+    File.exists?(pwsh) ? pwsh : nil
+  end
+
+  # Based on which command from https://github.com/puppetlabs/puppet/blob/1c14d0a9fdfc31933603e571b616b6cd675e6b71/lib/puppet/util.rb#L241-L286
+  # Resolve a path for an executable to the absolute path. This tries to behave
+  # in the same manner as the unix `which` command and uses the `PATH`
+  # environment variable.
+  #
+  # @api private
+  # @param bin [String] the name of the executable to find.
+  # @param custom_paths [String[]] the additional paths to look in first and then the PATH
+  # @return [String] the absolute path to the found executable.
+  def which_with_custom_env(bin, custom_paths = [])
+    if absolute_path?(bin)
+      return bin if FileTest.file? bin and FileTest.executable? bin
+    else
+      exts = Puppet::Util.get_env('PATHEXT')
+      exts = exts ? exts.split(File::PATH_SEPARATOR) : %w[.COM .EXE .BAT .CMD]
+      (custom_paths + Puppet::Util.get_env('PATH').split(File::PATH_SEPARATOR)).each do |dir|
+        begin
+          dest = File.expand_path(File.join(dir, bin))
+        rescue ArgumentError => e
+          # if the user's PATH contains a literal tilde (~) character and HOME is not set, we may get
+          # an ArgumentError here.  Let's check to see if that is the case; if not, re-raise whatever error
+          # was thrown.
+          if e.to_s =~ /HOME/ and (Puppet::Util.get_env('HOME').nil? || Puppet::Util.get_env('HOME') == "")
+            # if we get here they have a tilde in their PATH.  We'll issue a single warning about this and then
+            # ignore this path element and carry on with our lives.
+            #TRANSLATORS PATH and HOME are environment variables and should not be translated
+            Puppet::Util::Warnings.warnonce(_("PATH contains a ~ character, and HOME is not set; ignoring PATH element '%{dir}'.") % { dir: dir })
+          elsif e.to_s =~ /doesn't exist|can't find user/
+            # ...otherwise, we just skip the non-existent entry, and do nothing.
+            #TRANSLATORS PATH is an environment variable and should not be translated
+            Puppet::Util::Warnings.warnonce(_("Couldn't expand PATH containing a ~ character; ignoring PATH element '%{dir}'.") % { dir: dir })
+          else
+            raise
+          end
+        else
+          if Puppet::Util::Platform.windows? && File.extname(dest).empty?
+            exts.each do |ext|
+              destext = File.expand_path(dest + ext)
+              return destext if FileTest.file? destext and FileTest.executable? destext
+            end
+          end
+          return dest if FileTest.file? dest and FileTest.executable? dest
+        end
+      end
+    end
+    nil
+  end
+
   def write_script(content, &block)
     Tempfile.open(['puppet-pwsh', '.ps1']) do |file|
       file.puts(content)

--- a/metadata.json
+++ b/metadata.json
@@ -26,16 +26,45 @@
       ]
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "14.04",
-        "16.04"
-      ]
-    },
-    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "27",
+        "28"
+      ]
+    },
+    {
+      "operatingsystem": "OSX ",
+      "operatingsystemrelease": [
+        "10.12",
+        "10.13",
+        "10.14"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04",
+        "18.04"
       ]
     }
   ],

--- a/spec/integration/provider/exec/pwsh_spec.rb
+++ b/spec/integration/provider/exec/pwsh_spec.rb
@@ -1,0 +1,71 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/util'
+require 'fileutils'
+
+# Helper function to determine if PowerShell Core (pwsh) is available in the PATH.
+$pwsh_path_exist = nil
+def pwsh_exist?
+  return $pwsh_path_exist unless $pwsh_path_exist.nil?
+
+  name = Puppet.features.microsoft_windows? ? 'pwsh.exe' : 'pwsh'
+  result = ENV['PATH'].split(File::PATH_SEPARATOR).map {|p| File.join(p, name)}.find {|f| File.executable?(f)}
+
+  $pwsh_path_exist = !result.nil?
+end
+
+describe Puppet::Type.type(:exec).provider(:pwsh) do
+  let(:command)  { '$(Get-CIMInstance Win32_Account -Filter "SID=\'S-1-5-18\'") | Format-List' }
+  let(:args) { '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command -' }
+
+  let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :pwsh) }
+  let(:provider) { described_class.new(resource) }
+
+  describe "#run" do
+    # The usage of uname is a little fragile however there is basically nothing
+    # which is universal across all Linux/Unix/Mac distributions; Unlike Well Known SIDS in Windows
+    # The closest is the presence of the uname command and its generic text output
+    let(:command) { Puppet.features.microsoft_windows? ?
+      '$(Get-CIMInstance Win32_Account -Filter "SID=\'S-1-5-18\'") | Format-List' :
+      '& uname' }
+    let(:command_output_regex) { Puppet.features.microsoft_windows? ? /SID\s+:\s+S-1-5-18/ : /(Linux|Darwin)/ }
+
+    it "returns the output and status" do
+      skip('Could not locate pwsh binary') unless pwsh_exist?
+      output, status = provider.run(command)
+
+      expect(output).to match(command_output_regex)
+      expect(status.exitstatus).to eq(0)
+    end
+
+    it "returns true if the `onlyif` check command succeeds" do
+      skip('Could not locate pwsh binary') unless pwsh_exist?
+      resource[:onlyif] = command
+
+      expect(resource.parameter(:onlyif).check(command)).to eq(true)
+    end
+
+    it "returns false if the `unless` check command succeeds" do
+      skip('Could not locate pwsh binary') unless pwsh_exist?
+      resource[:unless] = command
+
+      expect(resource.parameter(:unless).check(command)).to eq(false)
+    end
+
+    it "runs commands properly that output to multiple streams" do
+      skip('Could not locate pwsh binary') unless pwsh_exist?
+      command = Puppet.features.microsoft_windows? ?
+        'echo "foo"; [System.Console]::Error.WriteLine("bar"); cmd.exe /c foo.exe' :
+        'echo "foo"; [System.Console]::Error.WriteLine("bar"); & foo.exe'
+      expected = Puppet.features.microsoft_windows? ?
+        "foo\nbar\n'foo.exe' is not recognized as an internal or external command,\noperable program or batch file.\n" :
+        "^foo\nbar\n.+The term \'foo\.exe\' is not recognized as the name of a cmdlet, function.+"
+
+      output, status = provider.run(command)
+
+      # Due to the different behaviour of uname across non-Windows platforms, must use a regex
+      expect(output).to match(expected)
+      expect(status.exitstatus).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
~~Builds on PR #245~~

---

Previously the pwsh provider only looked in the system path and some
predefined paths on Windows.  However PowerShell Core can be installed
anywhere as it is now a tarball/zipfile installation.  This means a
user should be able to arbitrarily define a location for the provider
to use.

This commit removes the :pwsh command because command resolution
can not use a custom path when searching. This is normally used to see
if a provider is applicable.  It is then replaced by a method called
get_pwsh_command which uses a copy of the Puppet `which` command which
can use custom search paths when locating binaries.

Note we can not extend or update the Puppet version of this code as
the which method is private. In this case we copy the code verbatim
and then modify it.

This commit also will now fail a catalog apply if pwsh can not be
located. Previously it would error that no suitable provider could
be found.

This commit also updates the READMe and metadata.json to reflect the
operating systems that the pwsh provider will run on.