### PR TITLE
(MODULES-8356) Improve pwsh searching

### DIFF
--- a/spec/unit/provider/exec/pwsh_spec.rb
+++ b/spec/unit/provider/exec/pwsh_spec.rb
@@ -84,6 +84,17 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
         provider.run_spec_override(command)
       end
     end
+
+    it "should only attempt to find pwsh once when pwsh exists" do
+      # Need to unstub to force the 'only once' expectation. Otherwise the
+      # previous stub takes over if it's called more than once.
+      provider.unstub(:get_pwsh_command)
+      provider.expects(:get_pwsh_command).once.returns('somepath/pwsh')
+
+      provider.run_spec_override(command)
+      provider.run_spec_override(command)
+      provider.run_spec_override(command)
+    end
   end
 
   describe "#checkexe" do


### PR DESCRIPTION
Previously the pwsh provider was modified to search for the pwsh binary
in a user specified path.  However this introduces a lot of new code.
This commit removes the redundant code and uses a public method within
Puppet (.withenv) to actually do the searching

This commit also uses a simple memoizing pattern to remember the path
to avoid costly IO when searching.  This commit also adds tests for
this scenario.