### PR TITLE
(MODULES-8358) Add PowerShell manager to pwsh provider

### DIFF
--- a/spec/acceptance/exec_pwsh_spec.rb
+++ b/spec/acceptance/exec_pwsh_spec.rb
@@ -4,7 +4,7 @@ def windows_platform?(host)
   !((host.platform =~ /^windows.*$/).nil?)
 end
 
-powershell6_agents = hosts_as('powershell6')
+powershell6_agents = hosts.select { |h| !(h['powershell'].nil?) }
 posix6_agents      = powershell6_agents.select { |a| !windows_platform?(a) }
 windows6_agents    = powershell6_agents.select { |a| windows_platform?(a) }
 

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -30,21 +30,16 @@ module PuppetX
   end
 end
 
-describe PuppetX::PowerShell::PowerShellManager,
-  :if => Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported? do
+shared_examples_for "a PowerShellManager" do |ps_command, ps_args|
 
-  let(:ps_command) { Puppet::Type.type(:exec).provider(:powershell).command(:powershell) }
-  let(:ps_args) { Puppet::Type.type(:exec).provider(:powershell).powershell_args }
-
-  let (:manager_args) {
-    provider = Puppet::Type.type(:exec).provider(:powershell)
-    powershell = provider.command(:powershell)
-    cli_args = provider.powershell_args
-    "#{powershell} #{cli_args.join(' ')}"
-  }
+describe PuppetX::PowerShell::PowerShellManager do
 
   def create_manager(ps_command, ps_args)
     PuppetX::PowerShell::PowerShellManager.instance(ps_command, ps_args, debug: true)
+  end
+
+  def line_end
+    Puppet::Util::Platform.windows? ? "\r\n" : "\n"
   end
 
   let (:manager) { create_manager(ps_command, ps_args) }
@@ -100,6 +95,7 @@ describe PuppetX::PowerShell::PowerShellManager,
           '^' + Regexp.escape("\#<#{epipe.class}: #{epipe.message}")
         )
       end
+
       # reason should be a string for an exact match
       # else an array of regex matches
       def expect_dead_manager(manager, reason, style = :exact)
@@ -124,7 +120,7 @@ describe PuppetX::PowerShell::PowerShellManager,
       end
 
       def expect_different_manager_returned_than(manager, pid)
-        # acquire another manager instance
+        # acquire another manager instance using the same command and arguments
         new_manager = create_manager(manager.powershell_command, manager.powershell_arguments)
 
         # which should be different than the one passed in
@@ -159,97 +155,108 @@ describe PuppetX::PowerShell::PowerShellManager,
 
       it "should create a new PowerShell manager host if the underlying PowerShell process is killed" do
         first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
-
         # kill the PID from Ruby
-        process = manager.instance_variable_get(:@ps_process)
-        Process.kill('KILL', process.pid)
+        # Note - On Windows, creating the powershell manager starts one process, whereas on unix it starts two (one via sh and one via pwsh). Not sure why
+        # So instead kill the parent process instead of the child
+        Process.kill('KILL', first_pid.to_i)
 
-        expect_dead_manager(manager, pipe_error_regex, :regex)
-
-        expect_different_manager_returned_than(manager, first_pid)
-      end
-
-      it "should create a new PowerShell manager host if the input stream is closed" do
-        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
-
-        # closing pipe from the Ruby side tears down the process
-        close_stream(manager.instance_variable_get(:@pipe), :inprocess)
-
-        expect_dead_manager(manager, IOError.new('closed stream').inspect, :exact)
+        # Windows uses named pipes, unix uses sockets
+        Puppet::Util::Platform.windows? ?
+          expect_dead_manager(manager, pipe_error_regex, :regex) :
+          # WSL raises an EOFError
+          # Ubuntu 16.04 raises an ECONNRESET:Connection reset by peer
+          expect_dead_manager(manager,
+            [EOFError.new('end of file reached').inspect, Errno::ECONNRESET.new.inspect],
+            :exact
+          )
 
         expect_different_manager_returned_than(manager, first_pid)
       end
 
-      it "should create a new PowerShell manager host if the input stream handle is closed" do
-        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+      context "on Windows", :if => Puppet::Util::Platform.windows? do
+        # On Windows we're using named pipes so these tests only apply on Windows.
+        it "should create a new PowerShell manager host if the input stream is closed" do
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
-        # call CloseHandle against pipe, therby tearing down the PowerShell process
-        close_stream(manager.instance_variable_get(:@pipe), :viahandle)
+          # closing pipe from the Ruby side tears down the process
+          close_stream(manager.instance_variable_get(:@pipe), :inprocess)
 
-        expect_dead_manager(manager, bad_file_descriptor_regex, :regex)
+          expect_dead_manager(manager, IOError.new('closed stream').inspect, :exact)
 
-        expect_different_manager_returned_than(manager, first_pid)
-      end
+          expect_different_manager_returned_than(manager, first_pid)
+        end
 
-      it "should create a new PowerShell manager host if the output stream is closed" do
-        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        it "should create a new PowerShell manager host if the input stream handle is closed" do
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
-        # closing stdout from the Ruby side allows process to run
-        close_stream(manager.instance_variable_get(:@stdout), :inprocess)
+          # call CloseHandle against pipe, therby tearing down the PowerShell process
+          close_stream(manager.instance_variable_get(:@pipe), :viahandle)
 
-        # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
-        msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
-        expect_dead_manager(manager, msgs, :exact)
+          expect_dead_manager(manager, bad_file_descriptor_regex, :regex)
 
-        expect_different_manager_returned_than(manager, first_pid)
-      end
+          expect_different_manager_returned_than(manager, first_pid)
+        end
 
-      it "should create a new PowerShell manager host if the output stream handle is closed" do
-        # currently skipped as it can trigger an internal Ruby thread clean-up race
-        # its unknown why this test fails, but not the identical test against @stderr
-        skip('This test can cause intermittent segfaults in Ruby with w32_reset_event invalid handle')
-        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        it "should create a new PowerShell manager host if the output stream is closed" do
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
-        # call CloseHandle against stdout, which leaves PowerShell process running
-        close_stream(manager.instance_variable_get(:@stdout), :viahandle)
+          # closing stdout from the Ruby side allows process to run
+          close_stream(manager.instance_variable_get(:@stdout), :inprocess)
 
-        # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
-        msgs = [
-          '^' + Regexp.escape(Errno::EPIPE.new().inspect),
-          bad_file_descriptor_regex
-        ]
-        expect_dead_manager(manager, msgs, :regex)
+          # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
+          msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
+          expect_dead_manager(manager, msgs, :exact)
 
-        expect_different_manager_returned_than(manager, first_pid)
-      end
+          expect_different_manager_returned_than(manager, first_pid)
+        end
 
-      it "should create a new PowerShell manager host if the error stream is closed" do
-        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        it "should create a new PowerShell manager host if the output stream handle is closed" do
+          # currently skipped as it can trigger an internal Ruby thread clean-up race
+          # its unknown why this test fails, but not the identical test against @stderr
+          skip('This test can cause intermittent segfaults in Ruby with w32_reset_event invalid handle')
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
-        # closing stderr from the Ruby side allows process to run
-        close_stream(manager.instance_variable_get(:@stderr), :inprocess)
+          # call CloseHandle against stdout, which leaves PowerShell process running
+          close_stream(manager.instance_variable_get(:@stdout), :viahandle)
 
-        # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
-        msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
-        expect_dead_manager(manager, msgs, :exact)
+          # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
+          msgs = [
+            '^' + Regexp.escape(Errno::EPIPE.new().inspect),
+            bad_file_descriptor_regex
+          ]
+          expect_dead_manager(manager, msgs, :regex)
 
-        expect_different_manager_returned_than(manager, first_pid)
-      end
+          expect_different_manager_returned_than(manager, first_pid)
+        end
 
-      it "should create a new PowerShell manager host if the error stream handle is closed" do
-        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        it "should create a new PowerShell manager host if the error stream is closed" do
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
 
-        # call CloseHandle against stderr, which leaves PowerShell process running
-        close_stream(manager.instance_variable_get(:@stderr), :viahandle)
+          # closing stderr from the Ruby side allows process to run
+          close_stream(manager.instance_variable_get(:@stderr), :inprocess)
 
-        # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
-        msgs = [
-          '^' + Regexp.escape(Errno::EPIPE.new().inspect),
-          bad_file_descriptor_regex
-        ]
-        expect_dead_manager(manager, msgs, :regex)
+          # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
+          msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
+          expect_dead_manager(manager, msgs, :exact)
 
-        expect_different_manager_returned_than(manager, first_pid)
+          expect_different_manager_returned_than(manager, first_pid)
+        end
+
+        it "should create a new PowerShell manager host if the error stream handle is closed" do
+          first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+          # call CloseHandle against stderr, which leaves PowerShell process running
+          close_stream(manager.instance_variable_get(:@stderr), :viahandle)
+
+          # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
+          msgs = [
+            '^' + Regexp.escape(Errno::EPIPE.new().inspect),
+            bad_file_descriptor_regex
+          ]
+          expect_dead_manager(manager, msgs, :regex)
+
+          expect_different_manager_returned_than(manager, first_pid)
+        end
       end
     end
   end
@@ -267,14 +274,14 @@ describe PuppetX::PowerShell::PowerShellManager,
     it "should return simple output" do
       result = manager.execute('write-output foo')
 
-      expect(result[:stdout]).to eq("foo\r\n")
+      expect(result[:stdout]).to eq("foo#{line_end}")
       expect(result[:exitcode]).to eq(0)
     end
 
     it "should return the exitcode specified" do
       result = manager.execute('write-output foo; exit 55')
 
-      expect(result[:stdout]).to eq("foo\r\n")
+      expect(result[:stdout]).to eq("foo#{line_end}")
       expect(result[:exitcode]).to eq(55)
     end
 
@@ -286,9 +293,11 @@ describe PuppetX::PowerShell::PowerShellManager,
     end
 
     it "should return the exitcode of the last command to set an exit code" do
-      result = manager.execute("$LASTEXITCODE = 0; write-output 'foo'; cmd.exe /c 'exit 99'; write-output 'bar'")
+      result =Puppet::Util::Platform.windows? ?
+        manager.execute("$LASTEXITCODE = 0; write-output 'foo'; cmd.exe /c 'exit 99'; write-output 'bar'") :
+        manager.execute("$LASTEXITCODE = 0; write-output 'foo'; /bin/sh -c 'exit 99'; write-output 'bar'")
 
-      expect(result[:stdout]).to eq("foo\r\nbar\r\n")
+      expect(result[:stdout]).to eq("foo#{line_end}bar#{line_end}")
       expect(result[:exitcode]).to eq(99)
     end
 
@@ -303,31 +312,50 @@ describe PuppetX::PowerShell::PowerShellManager,
     it "should collect anything written to stderr" do
       result = manager.execute('[System.Console]::Error.WriteLine("foo")')
 
-      expect(result[:stderr]).to eq(["foo\r\n"])
+      expect(result[:stderr]).to eq(["foo#{line_end}"])
       expect(result[:exitcode]).to eq(0)
     end
 
     it "should collect multiline output written to stderr" do
       # induce a failure in cmd.exe that emits a multi-iline error message
-      result = manager.execute('cmd.exe /c foo.exe')
+      result = Puppet::Util::Platform.windows? ?
+        manager.execute('cmd.exe /c foo.exe') :
+        manager.execute('/bin/sh -c "echo bar 1>&2 && foo.exe"')
 
       expect(result[:stdout]).to eq(nil)
-      expect(result[:stderr]).to eq(["'foo.exe' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n"])
-      expect(result[:exitcode]).to eq(1)
+      if Puppet::Util::Platform.windows?
+        expect(result[:stderr]).to eq(["'foo.exe' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n"])
+      else
+        expect(result[:stderr][0]).to match(/foo\.exe: not found/)
+        expect(result[:stderr][0]).to match(/bar/)
+      end
+      expect(result[:exitcode]).to_not eq(0)
     end
 
-    it "should handle writting to stdout and stderr" do
-      result = manager.execute('ps;[System.Console]::Error.WriteLine("foo")')
+    it "should handle writting to stdout (cmdlet) and stderr" do
+      result = manager.execute('Write-Host "powershell";[System.Console]::Error.WriteLine("foo")')
 
       expect(result[:stdout]).not_to eq(nil)
-      expect(result[:stderr]).to eq(["foo\r\n"])
+      expect(result[:native_stdout]).to eq(nil)
+      expect(result[:stderr]).to eq(["foo#{line_end}"])
+      expect(result[:exitcode]).to eq(0)
+    end
+
+    it "should handle writting to stdout (shell out to another program) and stderr" do
+      result = Puppet::Util::Platform.windows? ?
+        manager.execute('cmd.exe /c echo powershell;[System.Console]::Error.WriteLine("foo")') :
+        manager.execute('/bin/sh -c "echo powershell";[System.Console]::Error.WriteLine("foo")')
+
+      expect(result[:stdout]).to eq(nil)
+      expect(result[:native_stdout]).not_to eq(nil)
+      expect(result[:stderr]).to eq(["foo#{line_end}"])
       expect(result[:exitcode]).to eq(0)
     end
 
     it "should handle writing to stdout natively" do
       result = manager.execute('[System.Console]::Out.WriteLine("foo")')
 
-      expect(result[:stdout]).to eq("foo\r\n")
+      expect(result[:stdout]).to eq("foo#{line_end}")
       expect(result[:native_stdout]).to eq(nil)
       expect(result[:stderr]).to eq([])
       expect(result[:exitcode]).to eq(0)
@@ -336,26 +364,26 @@ describe PuppetX::PowerShell::PowerShellManager,
     it "should properly interleave output written natively to stdout and via Write-XXX cmdlets" do
       result = manager.execute('Write-Output "bar"; [System.Console]::Out.WriteLine("foo"); Write-Warning "baz";')
 
-      expect(result[:stdout]).to eq("bar\r\nfoo\r\nWARNING: baz\r\n")
+      expect(result[:stdout]).to eq("bar#{line_end}foo#{line_end}WARNING: baz#{line_end}")
       expect(result[:stderr]).to eq([])
       expect(result[:exitcode]).to eq(0)
     end
 
     it "should handle writing to regularly captured output AND stdout natively" do
-      result = manager.execute('ps;[System.Console]::Out.WriteLine("foo")')
+      result = manager.execute('Write-Host "powershell";[System.Console]::Out.WriteLine("foo")')
 
-      expect(result[:stdout]).not_to eq("foo\r\n")
+      expect(result[:stdout]).not_to eq("foo#{line_end}")
       expect(result[:native_stdout]).to eq(nil)
       expect(result[:stderr]).to eq([])
       expect(result[:exitcode]).to eq(0)
     end
 
     it "should handle writing to regularly captured output, stderr AND stdout natively" do
-      result = manager.execute('ps;[System.Console]::Out.WriteLine("foo");[System.Console]::Error.WriteLine("bar")')
+      result = manager.execute('Write-Host "powershell";[System.Console]::Out.WriteLine("foo");[System.Console]::Error.WriteLine("bar")')
 
-      expect(result[:stdout]).not_to eq("foo\r\n")
+      expect(result[:stdout]).not_to eq("foo#{line_end}")
       expect(result[:native_stdout]).to eq(nil)
-      expect(result[:stderr]).to eq(["bar\r\n"])
+      expect(result[:stderr]).to eq(["bar#{line_end}"])
       expect(result[:exitcode]).to eq(0)
     end
 
@@ -371,7 +399,7 @@ describe PuppetX::PowerShell::PowerShellManager,
         code = "Write-Output '#{mixed_utf8}'"
         result = manager.execute(code)
 
-        expect(result[:stdout]).to eq("#{mixed_utf8}\r\n")
+        expect(result[:stdout]).to eq("#{mixed_utf8}#{line_end}")
         expect(result[:exitcode]).to eq(0)
       end
 
@@ -379,13 +407,13 @@ describe PuppetX::PowerShell::PowerShellManager,
         code = "[System.Console]::Error.WriteLine('#{mixed_utf8}')"
         result = manager.execute(code)
 
-        expect(result[:stderr]).to eq(["#{mixed_utf8}\r\n"])
+        expect(result[:stderr]).to eq(["#{mixed_utf8}#{line_end}"])
         expect(result[:exitcode]).to eq(0)
       end
     end
 
     it "should execute cmdlets" do
-      result = manager.execute('ls')
+      result = manager.execute('Get-Verb')
 
       expect(result[:stdout]).not_to eq(nil)
       expect(result[:exitcode]).to eq(0)
@@ -477,13 +505,13 @@ try {
       manager.execute('[Environment]::SetEnvironmentVariable("foo", "bar", "process")')
       result = manager.execute('Test-Path env:\foo')
 
-      expect(result[:stdout]).to eq("False\r\n")
+      expect(result[:stdout]).to eq("False#{line_end}")
     end
 
     it "should set custom environment variables" do
       result = manager.execute('Write-Output $ENV:foo',nil,nil,['foo=bar'])
 
-      expect(result[:stdout]).to eq("bar\r\n")
+      expect(result[:stdout]).to eq("bar#{line_end}")
     end
 
     it "should remove custom environment variables between runs" do
@@ -502,15 +530,15 @@ try {
     it "should use last definition for duplicate custom environment variable" do
       result = manager.execute('Write-Output $ENV:foo',nil,nil,['foo=one','foo=two','foo=three'])
 
-      expect(result[:stdout]).to eq("three\r\n")
+      expect(result[:stdout]).to eq("three#{line_end}")
     end
 
-    def current_powershell_major_version
-      provider = Puppet::Type.type(:exec).provider(:powershell)
-      powershell = provider.command(:powershell)
-
+    def current_powershell_major_version(ps_command, ps_args)
+      # As this is only used to detect old PS versions we can
+      # short circuit detecting the version for PowerShell Core
+      return 6 if ps_command.end_with?('pwsh') || ps_command.end_with?('pwsh.exe')
       begin
-        version = `#{powershell} -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command \"$PSVersionTable.PSVersion.Major.ToString()\"`.chomp!.to_i
+        version = `#{ps_command} #{ps_args.join(' ')} -Command \"$PSVersionTable.PSVersion.Major.ToString()\"`.chomp!.to_i
       rescue
         puts "Unable to determine PowerShell version"
         version = -1
@@ -519,12 +547,12 @@ try {
       version
     end
 
-    def output_cmdlet
+    def output_cmdlet(ps_command, ps_args)
       # Write-Output is the default behavior, except on older PS2 where the
       # behavior of Write-Output introduces newlines after every width number
       # of characters as specified in the BufferSize of the custom console UI
       # Write-Host should usually be avoided, but works for this test in old PS2
-      current_powershell_major_version >= 3 ?
+      current_powershell_major_version(ps_command, ps_args) >= 3 ?
         'Write-Output' :
         'Write-Host'
     end
@@ -533,35 +561,34 @@ try {
       # this was tested successfully up to 5MB of text
       buffer_string_96k = 'a' * ((1024 * 96) + 1)
       result = manager.execute(<<-CODE
-'#{buffer_string_96k}' | #{output_cmdlet}
+'#{buffer_string_96k}' | #{output_cmdlet(ps_command, ps_args)}
         CODE
         )
 
       expect(result[:errormessage]).to eq(nil)
       expect(result[:exitcode]).to eq(0)
-      terminator = output_cmdlet == 'Write-Output' ? "\r\n" : "\n"
-      expect(result[:stdout]).to eq("#{buffer_string_96k}#{terminator}")
+      expect(result[:stdout].length).to eq("#{buffer_string_96k}#{line_end}".length)
+      expect(result[:stdout]).to eq("#{buffer_string_96k}#{line_end}")
     end
 
     it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
       result = manager.execute(<<-CODE
 $bytes_in_k = (1024 * 64) + 1
-[Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | #{output_cmdlet}
+[Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | #{output_cmdlet(ps_command, ps_args)}
         CODE
         )
 
       expect(result[:errormessage]).to eq(nil)
       expect(result[:exitcode]).to eq(0)
-      terminator = output_cmdlet == 'Write-Output' ? "\r\n" : "\n"
-      expected = "\x0" * (1024 * 64 + 1) + terminator
+      expected = "\x0" * (1024 * 64 + 1) + line_end
+      expect(result[:stdout].length).to eq(expected.length)
       expect(result[:stdout]).to eq(expected)
     end
 
     it "should return a response with a timeout error if the execution timeout is exceeded" do
       timeout_ms = 100
       result = manager.execute('sleep 1', timeout_ms)
-      # TODO What is the real message now?
-      msg = /Catastrophic failure\: PowerShell module timeout \(#{timeout_ms} ms\) exceeded while executing\r\n/
+      msg = /Catastrophic failure\: PowerShell module timeout \(#{timeout_ms} ms\) exceeded while executing/
       expect(result[:errormessage]).to match(msg)
     end
 
@@ -571,11 +598,12 @@ $bytes_in_k = (1024 * 64) + 1
       result = manager.execute(command, timeout_ms)
       expect(result[:exitcode]).to eq(1)
       # starts with Write-Output and Write-Debug messages
-      expect(result[:stdout]).to match(/^200 OK Glenn\r\nDEBUG: 304 Not Modified James\r\n/)
+      expect(result[:stdout]).to match(/200 OK Glenn/)
+      expect(result[:stdout]).to match(/DEBUG: 304 Not Modified James/)
       # then command may have \r\n injected, so remove those for comparison
       expect(result[:stdout].gsub(/\r\n/, '')).to include(command)
       # and it should end with the Write-Error content
-      expect(result[:stdout]).to end_with("404 Craig Not Found\r\n    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException\r\n    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException\r\n \r\n")
+      expect(result[:stdout]).to match(/404 Craig Not Found/)
     end
 
     it "should use a default timeout of 300 seconds if the user specified a timeout of 0" do
@@ -617,33 +645,34 @@ $bytes_in_k = (1024 * 64) + 1
       expect(result[:errormessage]).to match(/Working directory .+ does not exist/)
     end
 
-    it "should allow forward slashes in working directory" do
+    it "should allow forward slashes in working directory", :if => Puppet::Util::Platform.windows? do
+      # Backslashes only apply on Windows filesystems
       work_dir = ENV["WINDIR"]
       forward_work_dir = work_dir.gsub('\\','/')
 
       result = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
 
-      expect(result).to eq("#{work_dir}\r\n")
+      expect(result).to eq("#{work_dir}#{line_end}")
     end
 
     it "should use a specific working directory if set" do
-      work_dir = ENV["WINDIR"]
+      work_dir = Puppet::Util::Platform.windows? ? ENV["WINDIR"] : ENV["HOME"]
 
       result = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
 
-      expect(result).to eq("#{work_dir}\r\n")
+      expect(result).to eq("#{work_dir}#{line_end}")
     end
 
     it "should not reuse the same working directory between runs" do
-      work_dir = ENV["WINDIR"]
+      work_dir = Puppet::Util::Platform.windows? ? ENV["WINDIR"] : ENV["HOME"]
       current_work_dir = Dir.getwd
 
       first_cwd = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
       second_cwd = manager.execute('(Get-Location).Path')[:stdout]
 
       # Paths should be case insensitive
-      expect(first_cwd.downcase).to eq("#{work_dir}\r\n".downcase)
-      expect(second_cwd.downcase).to eq("#{current_work_dir}\r\n".downcase)
+      expect(first_cwd.downcase).to eq("#{work_dir}#{line_end}".downcase)
+      expect(second_cwd.downcase).to eq("#{current_work_dir}#{line_end}".downcase)
     end
 
     context "with runtime error" do
@@ -727,12 +756,12 @@ $bytes_in_k = (1024 * 64) + 1
       msg = SecureRandom.uuid.to_s.gsub('-', '')
       result = manager.execute("Write-Error '#{msg}'")
 
-      expect(result[:stdout]).to eq("Write-Error '#{msg}' : #{msg}\r\n    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException\r\n    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException\r\n \r\n")
+      expect(result[:stdout]).to match(/Write-Error '#{msg}' : #{msg}/)
       expect(result[:exitcode]).to eq(0)
     end
 
     it "should handle a Write-Error in the middle of code" do
-      result = manager.execute('ls;Write-Error "Hello";ps')
+      result = manager.execute('Write-Host "one" ;Write-Error "Hello"; Write-Host "two"')
 
       expect(result[:stdout]).not_to eq(nil)
       expect(result[:exitcode]).to eq(0)
@@ -741,7 +770,7 @@ $bytes_in_k = (1024 * 64) + 1
     it "should handle a Out-Default in the user code" do
       result = manager.execute('\'foo\' | Out-Default')
 
-      expect(result[:stdout]).to eq("foo\r\n")
+      expect(result[:stdout]).to eq("foo#{line_end}")
       expect(result[:exitcode]).to eq(0)
     end
 
@@ -768,5 +797,21 @@ $bytes_in_k = (1024 * 64) + 1
       expect(result[:exitcode]).to eq(0)
     end
   end
+end
+end
 
+if Puppet::Util::Platform.windows? && PuppetX::PowerShell::PowerShellManager.supported?
+  describe "On Windows PowerShell" do
+    it_should_behave_like "a PowerShellManager",
+      Puppet::Type.type(:exec).provider(:powershell).command(:powershell),
+      Puppet::Type.type(:exec).provider(:powershell).powershell_args
+  end
+end
+
+if PuppetX::PowerShell::PowerShellManager.supported_on_pwsh? && !Puppet::Type.type(:exec).provider(:pwsh).new().get_pwsh_command.nil?
+  describe "On PowerShell Core" do
+    it_should_behave_like "a PowerShellManager",
+      Puppet::Type.type(:exec).provider(:pwsh).new().get_pwsh_command,
+      Puppet::Type.type(:exec).provider(:pwsh).new().pwsh_args
+  end
 end

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -143,14 +143,9 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
   end
 
   describe 'when specifying a working directory' do
-    describe 'that does not exist' do
-      let(:work_dir)  {
-        if Puppet.features.microsoft_windows?
-          "#{ENV['SYSTEMROOT']}\\some\\directory\\that\\does\\not\\exist"
-        else
-          '/some/directory/that/does/not/exist'
-        end
-      }
+    describe 'that does not exist on Windows', :if => Puppet.features.microsoft_windows? do
+      # This working directory error is specific to the PowerShell manager on Windows.
+      let(:work_dir)  { "#{ENV['SYSTEMROOT']}\\some\\directory\\that\\does\\not\\exist" }
       let(:command)  { 'exit 0' }
       let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :powershell, :cwd => work_dir) }
       let(:provider) { described_class.new(resource) }


### PR DESCRIPTION
In preparation to add cross platform support to the PowerShell Manager,
this commit refactors the common execution code in the powershell provider into
the PuppetX::PowerShell::PowerShellManager.execute_resource method.  This
takes PowerShell code and a puppet exec resource and executes this using the
PowerShell Manager.

Previously the powershell command was a string which also contain the powershell
invocation commands.  This commit also separates the powershell command and arguments
so that we can call pwsh or powershell separately from the same PowerShell Manager.

---

Previously the pwsh provider would save a file to a temporary location and then
execute that. This is considered a legacy method.  The more modern method, which
is used in the Windows PowerShell provider, is to use the PowerShell Manager.

This commit updates the PowerShell Manager for using PowerShell Core on both
Windows and non-Windows platforms:

* The pwsh provider was modified to use the PowerShell manager if it is supported
  otherwise revert to the legacy temporary path

* The pwsh provider changed the scope of the pwsh_args and get_pwsh_command to
  public so that they can be used the spec tests.  As they're readonly properties
  it is safe to surface these methods

* Modified the PowerShell manager to use Unix Domain Sockets when on non-Windows
  platforms.  This is due to the .Net implmentation of the NamedPipesClient class
  using Domain Sockets on non-Windows platforms as opposed to Named Pipes. [1] [2] [3]
  The manager creates the domain sockets in the user's tmp directrory

  This also means the errors returned on bad/failed pipes is different e.g. EOFError
  and EConnReset.  Also many of the integration tests assume a real named pipe, so
  these tests are guarded to only run on Windows. Note that it was not possible to
  replicate the "delete named pipe" using Unix Domain sockets due to how sockets are
  different to named pipes.

* Modified many of the tests to either be platform independent by either removing the
  platform specific things e.g. remove \r\n references or specific exit codes.  Or the
  tests are modified to use specific items on specific platforms e.g. cmd.exe on Windows
  and /bin/sh on non-Windows.

* Removed the use of aliases (e.g. ps and ls) as they were causing test failures as they
  behave differently on different platforms.  Instead prefer commands like Get-Verb or
  $PSVersionTable which are consistent.

* Moved the 'when specifying a working directory' test from unit to integration as
  it actually calls the operating system for information and was causing failures when
  pwsh was not installed

* Modified the PowerShell Manager integration tests to be a shared example group and
  can then simply use 'it_behaves_like' calls to test when appropriate.  This is
  important on non-Windows when pwsh isn't installed.

* Modified the unit tests for the pwsh provider to use a mocked PowerShell Manager when
  invoked.

---

Previously the PowerShell Manager would attempt all the expected bytes from
the inbound pipe.  Normally this works fine.  However the Travis CI testing
was intermittently failing where the pipe was only reading half the pipe,
which then caused the first test to fail, and then any subsequent tests failed
because it was reading left-over data from the previous failed read.

The documentation of the IO.sysread method [1] says the argument is maxlen
which implies that this the maximum number of bytes it would return.  Note that
other methods in IO use the language "Reads at most maxlen bytes from ios"
whereas sysread uses the langauge "Reads maxlen bytes from ios"

This commit changes the pipe reader to read in chunks of bytes until all of
the expected bytes are read.  Note that this is a blocking call so if you
try to read beyond the bytes in the pipe it blocks the thread.  The value
of 8K chunk was an arbitrary number which is big enough to get most powershell
repsonse in a single IO read.  The integration tests were failing to read in
a 96K chunk (only ~36K were read)

---

- [x] Works in WSL
- [x] Works on real unix
- [x] Run PS Manager tests in unix (i.e. travis)