### PR TITLE
(MODULES-8358) Fix typo for EL based test hosts

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -50,7 +50,7 @@ unless ENV['MODULE_provision'] == 'no'
         on(host,'curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/microsoft.repo')
         # e.g. yum install -y powershell-6.1.2
         yum_text = "-#{ps_version}" unless ps_version.nil?
-        on(host,"sudo apt-get install -y powershell#{yum_text}")
+        on(host,"yum install -y powershell#{yum_text}")
       when /^windows/
         # Install PowerShell 6 if needed
         unless ps_version.nil?


### PR DESCRIPTION
Previously the spec_helper_acceptance was updated to install PowerShell core
of EL based operating systems e.g. CentOS 7, however the installation
instruction was accidentally copied from the ubuntu instructions which tried
to use Apt instead of Yum.  This commit fixes the typo error.