### PR TITLE
(MODULES-8359) Remove non-Windows support for powershell provider

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -3,13 +3,13 @@ require File.join(File.dirname(__FILE__), '../../../puppet_x/puppetlabs/powershe
 require File.join(File.dirname(__FILE__), '../../../puppet_x/puppetlabs/powershell/powershell_manager')
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
+  confine :operatingsystem => :windows
+
   commands :powershell =>
     if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")
       "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
     elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
       "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
-    elsif !Puppet::Util::Platform.windows?
-      'pwsh'
     else
       'powershell.exe'
     end
@@ -68,33 +68,21 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
   end
 
   def run(command, check = false)
-    if Puppet::Util::Platform.windows?
-      if !PuppetX::PowerShell::PowerShellManager.supported?
-        self.class.upgrade_message
-        write_script(command) do |native_path|
-          # Ideally, we could keep a handle open on the temp file in this
-          # process (to prevent TOCTOU attacks), and execute powershell
-          # with -File <path>. But powershell complains that it can't open
-          # the file for exclusive access. If we close the handle, then an
-          # attacker could modify the file before we invoke powershell. So
-          # we redirect powershell's stdin to read from the file. Current
-          # versions of Windows use per-user temp directories with strong
-          # permissions, but I'd rather not make (poor) assumptions.
-          return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
-        end
-      else
-        return ps_manager.execute_resource(command, resource)
-      end
-    else
+    if !PuppetX::PowerShell::PowerShellManager.supported?
+      self.class.upgrade_message
       write_script(command) do |native_path|
         # Ideally, we could keep a handle open on the temp file in this
         # process (to prevent TOCTOU attacks), and execute powershell
         # with -File <path>. But powershell complains that it can't open
         # the file for exclusive access. If we close the handle, then an
         # attacker could modify the file before we invoke powershell. So
-        # we redirect powershell's stdin to read from the file.
-        return super("sh -c \"#{native_path(command(:powershell))} #{posix_args} -Command - < #{native_path}\"", check)
+        # we redirect powershell's stdin to read from the file. Current
+        # versions of Windows use per-user temp directories with strong
+        # permissions, but I'd rather not make (poor) assumptions.
+        return super("cmd.exe /c \"\"#{native_path(command(:powershell))}\" #{legacy_args} -Command - < \"#{native_path}\"\"", check)
       end
+    else
+      return ps_manager.execute_resource(command, resource)
     end
   end
 
@@ -125,11 +113,5 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
 
   def legacy_args
     '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass'
-  end
-
-  def posix_args
-    # Note - using -ExecutionPolicy causes PowerShell to abort
-    # https://github.com/PowerShell/PowerShell/issues/2742
-    '-NoProfile -NonInteractive -NoLogo'
   end
 end

--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -31,8 +31,6 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
       "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
     elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
       "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
-    elsif !Puppet::Util::Platform.windows?
-      'pwsh'
     else
       'powershell.exe'
     end
@@ -156,7 +154,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
     end
   end
 
-  describe 'when applying a catalog' do
+  describe 'when applying a catalog', :if => Puppet.features.microsoft_windows? do
     let(:manifest) { <<-MANIFEST
       exec { 'PS':
         command   => 'exit 0',
@@ -205,8 +203,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
       transaction
     end
 
-    it 'does not emit a warning message when PowerShellManager is usable in a Windows environment',
-      :if => Puppet.features.microsoft_windows? do
+    it 'does not emit a warning message when PowerShellManager is usable in a Windows environment' do
 
       PuppetX::PowerShell::PowerShellManager.stubs(:win32console_enabled?).returns(false)
 
@@ -218,8 +215,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
       apply_compiled_manifest(manifest)
     end
 
-    it 'emits a warning message when PowerShellManager cannot be used in a Windows environment',
-      :if => Puppet.features.microsoft_windows? do
+    it 'emits a warning message when PowerShellManager cannot be used in a Windows environment' do
 
       # pretend we're Ruby 1.9.3 / Puppet 3.x x86
       PuppetX::PowerShell::PowerShellManager.stubs(:win32console_enabled?).returns(true)


### PR DESCRIPTION
Previously in MODULES-3495 cross platform support was added to the powershell
provider.  However as part of MODULES-8358 the pwsh provder was added to
achieve the same.  This means that the non-Windows platform support within the
powershell provider can be removed as it is no longer necessary.  Also note that
as this was marked as experimental, and had known issues with functioning
therefore the removal will not require a major version bump of the module.

This commit removes the support and also modifies the unit and acceptance tests
to not test the powershell provider on non-Windows platforms.