### PR TITLE
(MAINT) Update linux distro in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   # will work with our PowerShell manager code.
   - osx
 
-dist: trusty
+dist: xenial
 language: ruby
 cache: bundler
 before_install:


### PR DESCRIPTION
This commit updates our travis config to use xenial, 16.04 instead of trusty, 14.04, because trusty has reached EOL and is now causing errors.