### PR TITLE
(MODULES-9084) Increase pipe timeout to 180s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- Increase the named pipe timeout to 180 seconds to prevent runs from failing waiting for a pipe to open ([MODULES-9084](https://tickets.puppetlabs.com/browse/MODULES-9084)).
+
 ## [2.3.0] - 2019-04-19
 
 ### Added

--- a/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell/powershell_manager.rb
@@ -14,7 +14,7 @@ module PuppetX
       def self.default_options
         {
           debug: false,
-          pipe_timeout: 30
+          pipe_timeout: 180
         }
       end
 
@@ -85,7 +85,7 @@ module PuppetX
 
         Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
 
-        # wait up to 30 seconds in 0.2 second intervals to be able to open the pipe
+        # wait up to 180 seconds in 0.2 second intervals to be able to open the pipe
         # If the pipe_timeout is ever specified as less than the sleep interval it will
         # never try to connect to a pipe and error out as if a timeout occurred.
         sleep_interval = 0.2


### PR DESCRIPTION
This commit increases the timeout for waiting on the named
pipe to open. This resolves issues where servers under
heavy load do not open the pipe quickly enough.