### PR TITLE
(MODULES-10120) enable simplecov; update to PDK 1.14.1; minor cleanups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,14 @@ Bundler/DuplicatedGem:
   Enabled: false
 Bundler/OrderedGems:
   Enabled: false
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateString:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/AccessModifierIndentation:
   Enabled: false
 Layout/AlignArray:

--- a/.sync.yml
+++ b/.sync.yml
@@ -26,7 +26,5 @@ Gemfile:
     - gem: master_manipulator
     - gem: puppet-blacksmith
       version: "~> 3.4"
-spec/default_facts.yml:
-  unmanaged: true
 spec/spec_helper.rb:
   coverage_report: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,38 +1,30 @@
 ---
-Gemfile:
-  optional:
-    ':development':
-      - gem: 'ruby-pwsh'
-  required:
-    ':system_tests':
-      - gem: 'puppet-module-posix-system-r#{minor_version}'
-        platforms: ruby
-      - gem: 'puppet-module-win-system-r#{minor_version}'
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
-      - gem: beaker-testmode_switcher
-        version: '~> 0.4'
-      - gem: master_manipulator
-      - gem: puppet-blacksmith
-        version: '~> 3.4'
-
-# For the moment don't do any rubocop checks.
-.rubocop.yml:
+".gitlab-ci.yml":
+  delete: true
+".rubocop.yml":
   include_todos: true
-  selected_profile: off
-
-spec/default_facts.yml:
+  selected_profile: false
+".travis.yml":
   unmanaged: true
-
-# Due to https://github.com/puppetlabs/pdk-templates/issues/133 we can't manage Travis CI yet.
-.travis.yml:
-  unmanaged: true
-
-# Due to https://github.com/puppetlabs/pdk-templates/issues/229 we can't manage Appveyor yet.
 appveyor.yml:
   unmanaged: true
-
-.gitlab-ci.yml:
-  delete: true
+Gemfile:
+  optional:
+    ":development":
+    - gem: ruby-pwsh
+  required:
+    ":system_tests":
+    - gem: puppet-module-posix-system-r#{minor_version}
+      platforms: ruby
+    - gem: puppet-module-win-system-r#{minor_version}
+      platforms:
+      - mswin
+      - mingw
+      - x64_mingw
+    - gem: beaker-testmode_switcher
+      version: "~> 0.4"
+    - gem: master_manipulator
+    - gem: puppet-blacksmith
+      version: "~> 3.4"
+spec/default_facts.yml:
+  unmanaged: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -28,3 +28,5 @@ Gemfile:
       version: "~> 3.4"
 spec/default_facts.yml:
   unmanaged: true
+spec/spec_helper.rb:
+  coverage_report: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -12,19 +12,5 @@ Gemfile:
   optional:
     ":development":
     - gem: ruby-pwsh
-  required:
-    ":system_tests":
-    - gem: puppet-module-posix-system-r#{minor_version}
-      platforms: ruby
-    - gem: puppet-module-win-system-r#{minor_version}
-      platforms:
-      - mswin
-      - mingw
-      - x64_mingw
-    - gem: beaker-testmode_switcher
-      version: "~> 0.4"
-    - gem: master_manipulator
-    - gem: puppet-blacksmith
-      version: "~> 3.4"
 spec/spec_helper.rb:
   coverage_report: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,34 +23,37 @@ before_install:
   - gem --version
   - bundle -v
 script:
-  - 'bundle exec rake $CHECK'
+  - 'SIMPLECOV=yes bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.5.1
-env:
-  global:
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
-    - CHECK=parallel_spec
+  - 2.5.3
+stages:
+  - static
+  - spec
+  - acceptance
+  -
+    if: tag =~ ^v\d
+    name: deploy
 matrix:
   fast_finish: true
   include:
     -
-      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
+      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      stage: static
     -
-      env: PUPPET_GEM_VERSION="~> 5.0"
-      rvm: 2.4.4
+      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.5
+      stage: spec
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.3
+      stage: spec
+    -
+      env: DEPLOY_TO_FORGE=yes
+      stage: deploy
 branches:
   only:
     - master
     - /^v\d/
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: ""
-  on:
-    tags: true
-    all_branches: true
-condition: "$DEPLOY_TO_FORGE = yes"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
-gem 'pdk', git: 'https://github.com/puppetlabs/pdk.git', branch: 'master'
 
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
@@ -24,6 +23,7 @@ group :development do
   gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -30,13 +30,6 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "ruby-pwsh",                                               require: false
 end
-group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker-testmode_switcher", '~> 0.4',           require: false
-  gem "master_manipulator",                           require: false
-  gem "puppet-blacksmith", '~> 3.4',                  require: false
-end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,17 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['source'].match(%r{.*/([^/]*)})[1]
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 1.1.x.{build}
 branches:
   only:
     - master
+    - release
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10
@@ -13,6 +14,7 @@ init:
   - 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
   - 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
 environment:
+  SIMPLECOV: yes
   matrix:
     -
       RUBY_VERSION: 24-x64

--- a/metadata.json
+++ b/metadata.json
@@ -77,7 +77,7 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.14.0",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#1.11.1",
-  "template-ref": "1.11.1-0-g2ff8c24"
+  "pdk-version": "1.14.1",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#master",
+  "template-ref": "heads/master-0-gfaf9e8b"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,5 +3,6 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.before :each do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |c|
   end
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
+    RSpec::Puppet::Coverage.report!(0)
   end
 end
 


### PR DESCRIPTION
This PR was created using this script in stages running `pdk update` and committing individual changes in multiple iterations. Some manual fixes interspersed to reduce aberrations.

```
#! /usr/bin/ruby
require 'yaml'

contents = YAML.load(File.read(".sync.yml"))

contents[".gitlab-ci.yml"] = {'delete' => true}
contents["spec/spec_helper.rb"] ||= {}
contents["spec/spec_helper.rb"]['coverage_report'] = true

gitignore = contents[".gitignore"] ||= {}
gitignore["required"] ||= []
gitignore["required"] -= ["---.project"]
gitignore.delete("required") if gitignore["required"].empty?
contents.delete(".gitignore") if contents[".gitignore"].empty?

contents.delete("spec/default_facts.yml") if contents["spec/default_facts.yml"] == {"unmanaged" => true}

[".travis.yml", "appveyor.yml"].each do |f|
  contents[f] ||= {}
  if contents[f]["unmanaged"] != true && contents[f]["delete"] != true
    contents[f]["simplecov"] = true
  end
end

contents = Hash[contents.keys.sort{|a,b| a.upcase <=> b.upcase}.map{|k| [k, contents[k]]}]
File.open(".sync.yml", "w") { |file| file.write(contents.to_yaml(line_width: 200)) }
```
