### PR TITLE
(MODULES-10389) - Safeguard powershell provider loading

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -1,14 +1,18 @@
 require 'puppet/provider/exec'
-begin
-  require 'ruby-pwsh'
-rescue LoadError
-  raise 'Could not load the "ruby-pwsh" library; is the dependency module puppetlabs-pwshlib installed in this environment?'
-end
 
 Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec do
   confine :operatingsystem => :windows
+  confine :feature => :pwshlib
 
-  commands :powershell => Pwsh::Manager.powershell_path
+  def self.powershell_path
+    begin
+      require 'ruby-pwsh'
+      Pwsh::Manager.powershell_path
+    rescue
+      nil
+    end
+  end
+  commands :powershell => self.powershell_path
 
   desc <<-EOT
     Executes Powershell commands. One of the `onlyif`, `unless`, or `creates`

--- a/lib/puppet/provider/exec/pwsh.rb
+++ b/lib/puppet/provider/exec/pwsh.rb
@@ -1,11 +1,8 @@
 require 'puppet/provider/exec'
-begin
-  require 'ruby-pwsh'
-rescue LoadError
-  raise 'Could not load the "ruby-pwsh" library; is the dependency module puppetlabs-pwshlib installed in this environment?'
-end
 
 Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
+  confine :feature => :pwshlib
+  
   desc <<-EOT
     Executes PowerShell Core commands. One of the `onlyif`, `unless`, or `creates`
     parameters should be specified to ensure the command is idempotent.


### PR DESCRIPTION
This modifies the providers to use a confine statement to a feature found in the dependent pwshlib module, preventing Puppet runs from failing outright if the dependency is not found.