### PR TITLE
Correct supported Puppet lower bound to 5.5.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -74,7 +74,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 5.5.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.15.0",


### PR DESCRIPTION
Prior to this commit the metadata erroneously claimed support for 4x versions of Puppet, on which it has not been tested and would fail to run as the `ruby-pwsh` dependency requires Ruby 2.3 or higher which ships in Puppet 5x.

Further, Puppeet 4x is no longer officially supported at all.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-powershell/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12015&summary=%5BPOWERSHELL%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
