### PR TITLE
Fix issue on linux boxes

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     begin
       require 'ruby-pwsh'
       Pwsh::Manager.powershell_path
-    rescue
+    rescue LoadError
       nil
     end
   end


### PR DESCRIPTION
By default ruby rescue "StandardError", but the catch is that "LoadError" is not a subset of "StandardError"