### PR TITLE
Modules 10539

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     begin
       require 'ruby-pwsh'
       Pwsh::Manager.powershell_path
-    rescue 
+    rescue LoadError
       nil
     end
   end

--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     begin
       require 'ruby-pwsh'
       Pwsh::Manager.powershell_path
-    rescue
+    rescue 
       nil
     end
   end


### PR DESCRIPTION
Looks like powershell module with tag 3.0.1 brakes execution of puppet on out linux hosts, where we have no PowerShell nor pwsh.

By default ruby rescue "StandardError", but the catch is that "LoadError" is not a subset of "StandardError"
https://ruby-doc.org/core-2.5.0/Exception.html

https://tickets.puppetlabs.com/browse/MODULES-10539