### PR TITLE
(MODULES-10539) Remove commands idiom from PowerShell provider

### DIFF
--- a/spec/unit/provider/exec/powershell_spec.rb
+++ b/spec/unit/provider/exec/powershell_spec.rb
@@ -38,6 +38,7 @@ describe Puppet::Type.type(:exec).provider(:powershell) do
   describe "#run" do
     context "stubbed calls" do
       before :each do
+        require 'ruby-pwsh'
         Pwsh::Manager.stubs(:windows_powershell_supported?).returns(false)
         Puppet::Provider::Exec.any_instance.stubs(:run)
       end

--- a/spec/unit/provider/exec/pwsh_spec.rb
+++ b/spec/unit/provider/exec/pwsh_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 require 'spec_helper'
 require 'puppet/util'
+require 'ruby-pwsh'
 
 describe Puppet::Type.type(:exec).provider(:pwsh) do
   # Override the run value so we can test the super call


### PR DESCRIPTION
Prior to this commit the PowerShell exec provider used the commands idiom to
load the PowerShell executable path for use. Once the module was refactored
to rely on the ruby-pwsh gem via the puppetlabs/pwshlib module, the code for
determining the path was updated to depend on a helper function. However,
the commands method is (apparently?) evaluated during catalogue compilation,
causing the Puppet run to explode unexpectedly if the dependent module is
not available.

This commit removes the commands idiom and relies on the feature confine which
should evaluate during a Puppet run and, when that feature is not found
(because puppetlabs/pwshlib is not installed) it will report that the provider
is not functional rather than blow up the entire Puppet run.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-powershell/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12015&summary=%5BPOWERSHELL%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
