### PR TITLE
(maint) Remove interpolate_powershell method

### DIFF
--- a/spec/acceptance/exec_powershell_spec.rb
+++ b/spec/acceptance/exec_powershell_spec.rb
@@ -243,8 +243,8 @@ describe 'powershell provider:', if: (os[:family] == 'windows') do
     }
 
     after(:each) do
-      run_shell(interpolate_powershell("Remove-Item Env:\\superspecial -ErrorAction Ignore;exit 0"))
-      run_shell(interpolate_powershell("Remove-Item Env:\\outside -ErrorAction Ignore;exit 0"))
+      run_shell(PuppetLitmus::Util.interpolate_powershell("Remove-Item Env:\\superspecial -ErrorAction Ignore;exit 0"))
+      run_shell(PuppetLitmus::Util.interpolate_powershell("Remove-Item Env:\\outside -ErrorAction Ignore;exit 0"))
     end
 
     it 'should not see environment variable from previous run' do
@@ -258,7 +258,7 @@ describe 'powershell provider:', if: (os[:family] == 'windows') do
     it 'should see environment variables set outside of session' do
       # Setup the environment variable outside of Puppet
 
-      run_shell(interpolate_powershell("$env:outside='1'"))
+      run_shell(PuppetLitmus::Util.interpolate_powershell("$env:outside='1'"))
 
       # Test to see if initial run sees the environment variable
       apply_manifest(envar_leak_test_pp, expect_changes: true)

--- a/spec/acceptance/exec_pwsh_spec.rb
+++ b/spec/acceptance/exec_pwsh_spec.rb
@@ -280,8 +280,8 @@ describe 'pwsh provider:' do
       after(:each) do
         # Due to https://tickets.puppetlabs.com/browse/BKR-1088, need to use different commands
         if windows_platform?
-          run_shell(interpolate_powershell("Remove-Item Env:\\superspecial -ErrorAction Ignore;exit 0"))
-          run_shell(interpolate_powershell("Remove-Item Env:\\outside -ErrorAction Ignore;exit 0"))
+          run_shell(PuppetLitmus::Util.interpolate_powershell("Remove-Item Env:\\superspecial -ErrorAction Ignore;exit 0"))
+          run_shell(PuppetLitmus::Util.interpolate_powershell("Remove-Item Env:\\outside -ErrorAction Ignore;exit 0"))
         else
           run_shell('unset superspecial')
           run_shell('unset outside')
@@ -301,7 +301,7 @@ describe 'pwsh provider:' do
   
         # Due to https://tickets.puppetlabs.com/browse/BKR-1088, need to use different commands
         if windows_platform?
-          run_shell(interpolate_powershell("\$env:outside='1'"))
+          run_shell(PuppetLitmus::Util.interpolate_powershell("\$env:outside='1'"))
         else
           run_shell('export outside=1')
         end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,4 +1,5 @@
 require 'puppet_litmus'
+require 'puppet_litmus/util'
 require 'singleton'
 
 class Helper
@@ -32,7 +33,7 @@ def uninstall_pwsh
             when 'darwin'
               'brew cask uninstall powershell'
             when 'windows'
-              interpolate_powershell('Get-Command pwsh | ForEach-Object { Remove-Item -Path (Split-Path -Parent $_.Path) -Recurse -Force }')
+              PuppetLitmus::Util.interpolate_powershell('Get-Command pwsh | ForEach-Object { Remove-Item -Path (Split-Path -Parent $_.Path) -Recurse -Force }')
             end
   Helper.instance.run_shell(command)
 end
@@ -48,11 +49,6 @@ def cleanup_files
                             'file{["/tmp/services.txt","/tmp/process.txt","/tmp/try_success.txt","/tmp/catch_shouldntexist.txt","/tmp/try_shouldntexist.txt","/tmp/catch_success.txt"]: ensure => absent }'
                           end
   Helper.instance.apply_manifest(absent_files_manifest, catch_failures: true)
-end
-
-def interpolate_powershell(command)
-  encoded_command = Base64.strict_encode64(command.encode('UTF-16LE'))
-  "powershell.exe -NoProfile -EncodedCommand #{encoded_command}"
 end
 
 def relative_folder(relative_path)


### PR DESCRIPTION
This was added to Litmus so we can remove it here. Also prevents us having a method that could potentially diverge from the Litmus one.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-powershell/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12015&summary=%5BPOWERSHELL%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
