### PR TITLE
pdksync - Use abs instead of vmpooler to provision test resources

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -15,5 +15,5 @@ travis_el:
   provisioner: docker 
   images: ['waffleimage/centos7']
 release_checks:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['redhat-7-x86_64', 'redhat-8-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2012r2-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64']


### PR DESCRIPTION
Use abs instead of vmpooler to provision test resources
pdk version: `1.17.0` 
