### PR TITLE
(MODULES-10722) Inherit pipe_timeout from timeout

### DIFF
--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -45,9 +45,9 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     @upgrade_warning_issued = true
   end
 
-  def ps_manager
+  def ps_manager(pipe_timeout)
     debug_output = Puppet::Util::Log.level == :debug
-    Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args, debug: debug_output)
+    Pwsh::Manager.instance(Pwsh::Manager.powershell_path, Pwsh::Manager.powershell_args, debug: debug_output, pipe_timeout: pipe_timeout)
   end
 
   def run(command, check = false)
@@ -77,7 +77,7 @@ Puppet::Type.type(:exec).provide :powershell, :parent => Puppet::Provider::Exec 
     timeout_ms = resource[:timeout].nil? ? nil : resource[:timeout] * 1000
     environment_variables = resource[:environment].nil? ? [] : resource[:environment]
 
-    result = ps_manager.execute(powershell_code, timeout_ms, working_dir, environment_variables)
+    result = ps_manager(resource[:timeout]).execute(powershell_code, timeout_ms, working_dir, environment_variables)
     stdout     = result[:stdout]
     native_out = result[:native_stdout]
     stderr     = result[:stderr]

--- a/lib/puppet/provider/exec/pwsh.rb
+++ b/lib/puppet/provider/exec/pwsh.rb
@@ -68,9 +68,9 @@ Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
   #
   # @api private
   # @return [Pwsh::Manager] The PowerShell manager for this resource
-  def ps_manager
+  def ps_manager(pipe_timeout)
     debug_output = Puppet::Util::Log.level == :debug
-    Pwsh::Manager.instance(@pwsh, pwsh_args, debug: debug_output)
+    Pwsh::Manager.instance(@pwsh, pwsh_args, debug: debug_output, pipe_timeout: pipe_timeout)
   end
 
   def execute_resource(powershell_code, resource)
@@ -81,7 +81,7 @@ Puppet::Type.type(:exec).provide :pwsh, :parent => Puppet::Provider::Exec do
     timeout_ms = resource[:timeout].nil? ? nil : resource[:timeout] * 1000
     environment_variables = resource[:environment].nil? ? [] : resource[:environment]
 
-    result = ps_manager.execute(powershell_code, timeout_ms, working_dir, environment_variables)
+    result = ps_manager(resource[:timeout]).execute(powershell_code, timeout_ms, working_dir, environment_variables)
     stdout     = result[:stdout]
     native_out = result[:native_stdout]
     stderr     = result[:stderr]


### PR DESCRIPTION
Prior to this commit there was no way to modify the pipe_timeout
parameter when instantiating a PowerShell Manager instance, users
were stuck with the default defined in ruby-pwsh (30s). If this
time is insufficient to start the host process, the exec failed
with no way to extend it short of modifying the provider.

This commit updates the definition of the ps_manager by checking
to see if the timeout parameter is specified on the resource and,
if so, inheriting that to re-use for the pipe timeout.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-powershell/blob/main/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=12015&summary=%5BPOWERSHELL%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MAIN branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
