### PR TITLE
pdksync - Remove EL6 testing from Travis

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -22,9 +22,6 @@ travis_ub:
   images:
   - litmusimage/ubuntu:16.04
   - litmusimage/ubuntu:18.04
-travis_el6:
-  provisioner: docker
-  images: []
 travis_el7:
   provisioner: docker
   images:


### PR DESCRIPTION
Remove EL6 testing from Travis
pdk version: `1.18.1` 
