### PR TITLE
pdksync - (IAC-1598) - Remove Support for Debian 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10"
       ]


### PR DESCRIPTION
(IAC-1598) - Remove Support for Debian 8
pdk version: `1.18.1` 
