### PR TITLE
(IAC-1734) - Certify Debian 11

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/spec/fixtures/scripts/install_pwsh/debian_11.sh
+++ b/spec/fixtures/scripts/install_pwsh/debian_11.sh
@@ -1,0 +1,18 @@
+# Install system components
+apt-get update
+apt-get install -y curl gnupg apt-transport-https
+
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+# Register the Microsoft Product feed
+sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
+
+# Update the list of products
+apt-get update
+
+# Install PowerShell
+apt-get install -y powershell
+
+# List version
+pwsh -v


### PR DESCRIPTION
Work previously halted due to Powershell itself not yet fully supporting Debian 11