### PR TITLE
pdksync - (GH-cat-11) Certify Support for Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {

--- a/spec/fixtures/scripts/install_pwsh/ubuntu_22.04.sh
+++ b/spec/fixtures/scripts/install_pwsh/ubuntu_22.04.sh
@@ -1,0 +1,17 @@
+# Download the Microsoft repository GPG keys
+wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
+
+# Register the Microsoft repository GPG keys
+dpkg -i packages-microsoft-prod.deb
+
+# Update the list of products
+apt-get update
+
+# Enable the "universe" repositories
+add-apt-repository universe
+
+# Install PowerShell
+apt-get install -y powershell
+
+# List version
+pwsh -v


### PR DESCRIPTION
(GH-cat-11) Certify Support for Ubuntu 22.04
pdk version: `2.3.0` 
