### PR TITLE
(MAINT) Dropped support for Windows(7,8,2008 + 2008 R2(Server), Fedora(27+28) and OSX OS's(10.12-.14)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,11 +17,7 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "10",
-        "2008",
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",
@@ -42,21 +38,6 @@
         "9",
         "10",
         "11"
-      ]
-    },
-    {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "27",
-        "28"
-      ]
-    },
-    {
-      "operatingsystem": "OSX ",
-      "operatingsystemrelease": [
-        "10.12",
-        "10.13",
-        "10.14"
       ]
     },
     {


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
Support for Windows Server 2008 & 2008 R2 was removed. 
Support for Windows 7 & 8 was removed.
Support for Fedora 27 & 28 was removed.
Support for OSX 10.12, 10.13 & 10.14 was removed.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html
