### PR TITLE
(CONT-133) - Spec Test Failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem "rb-readline", '= 0.5.5',                        require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "ruby-pwsh",                                     require: false
   gem "github_changelog_generator",                    require: false
+  gem "mocha",                                         require: false
 end
 group :system_tests do
   gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]


### PR DESCRIPTION
Prior to this PR, the spec tests were failing on this module due to syntax that was no longer supported.

This PR aims to update the syntax, so that the spec tests run successfully again by replacing the unsupported syntax with its newer, supported counterparts.
