### PR TITLE
(CONT-133) Update outdated spec tests

### DIFF
--- a/spec/unit/provider/exec/pwsh_spec.rb
+++ b/spec/unit/provider/exec/pwsh_spec.rb
@@ -32,8 +32,6 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
     before :each do
       allow_any_instance_of(Puppet::Provider::Exec).to receive(:run)
       allow(provider).to receive(:execute_resource).and_return('','')
-      # Puppet::Provider::Exec.any_instance.stub(:run)
-      # provider.stub(:execute_resource).and_return('', '')
     end
 
     context 'when the powershell manager is not supported' do
@@ -63,7 +61,7 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
         # Path quoting is only required on Windows
         path = 'C:\Users\albert\AppData\Local\Temp\puppet-powershell20130715-788-1n66f2j.ps1'
 
-        expect(provider).to receive(:write_script).with(command).and_return(path)
+        expect(provider).to receive(:write_script).with(command).and_yield(path)
         expect(provider).to receive(:run).with(/#{shell_command} .* #{args} < .*/, false)
 
         provider.run_spec_override(command)
@@ -83,7 +81,7 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
           # Remove the global stub here as we're testing this method
           allow(Pwsh::Manager).to receive(:pwsh_path).and_call_original
 
-          expect(provider).to receive(:run).with(/#{native_pwsh_path}/, false)
+          expect(provider).to receive(:run).with(native_pwsh_path_regex, false)
           provider.run_spec_override(command)
         end
       end

--- a/spec/unit/provider/exec/pwsh_spec.rb
+++ b/spec/unit/provider/exec/pwsh_spec.rb
@@ -18,36 +18,43 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
   let(:args) { '-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command -' }
 
   let(:resource) { Puppet::Type.type(:exec).new(:command => command, :provider => :pwsh) }
-  let(:provider) { described_class.new(resource) }
+
+  subject(:provider) do
+    described_class.new(resource)
+  end
 
   before :each do
     # Always assume the pwsh binary is available
-    Pwsh::Manager.stubs(:pwsh_path).returns('somepath/pwsh')
+    allow(Pwsh::Manager).to receive(:pwsh_path).and_return('somepath/pwsh')
   end
 
   describe "#run" do
     before :each do
-      Puppet::Provider::Exec.any_instance.stubs(:run)
-      provider.stubs(:execute_resource).returns('', '')
+      allow_any_instance_of(Puppet::Provider::Exec).to receive(:run)
+      allow(provider).to receive(:execute_resource).and_return('','')
+      # Puppet::Provider::Exec.any_instance.stub(:run)
+      # provider.stub(:execute_resource).and_return('', '')
     end
 
     context 'when the powershell manager is not supported' do
       before :each do
-        Pwsh::Manager.stubs(:pwsh_supported?).returns(false)
+        Pwsh::Manager.stub(:pwsh_supported?).and_return(false)
       end
 
       let(:shell_command) { Puppet.features.microsoft_windows? ? 'cmd.exe /c' : '/bin/sh -c' }
 
       it "should call exec run" do
-        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
-
+        expect(provider).to receive(:run)
         provider.run_spec_override(command)
       end
 
       it "should call shell command" do
-        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run)
-          .with(regexp_matches(/#{shell_command}/), anything)
+        expect(provider).to receive(:run).with(/#{shell_command}/, anything)
+        provider.run_spec_override(command)
+      end
 
+      it "should supply default arguments to supress user interaction" do
+        expect(provider).to receive(:run).with(/#{shell_command} .* #{args} < .*/, false)
         provider.run_spec_override(command)
       end
 
@@ -56,16 +63,8 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
         # Path quoting is only required on Windows
         path = 'C:\Users\albert\AppData\Local\Temp\puppet-powershell20130715-788-1n66f2j.ps1'
 
-        provider.expects(:write_script).with(command).yields(path)
-        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
-          with(regexp_matches(/^#{shell_command} .* < "#{Regexp.escape(path)}"/), false)
-
-        provider.run_spec_override(command)
-      end
-
-      it "should supply default arguments to supress user interaction" do
-        Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
-          with(regexp_matches(/^#{shell_command} .* #{args} < .*"/), false)
+        expect(provider).to receive(:write_script).with(command).and_return(path)
+        expect(provider).to receive(:run).with(/#{shell_command} .* #{args} < .*/, false)
 
         provider.run_spec_override(command)
       end
@@ -80,15 +79,11 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
 
         it 'should prefer pwsh in the specified path' do
           # Pretend that only the test pwsh binary exists.
-          File.stubs(:exist?).with() { |value| value == pwsh_path}.returns(true)
-          File.stubs(:exist?).with() { |value| value != pwsh_path}.returns(false)
-
+          allow(File).to receive(:exist?).and_return(true)
           # Remove the global stub here as we're testing this method
-          Pwsh::Manager.unstub(:pwsh_path)
+          allow(Pwsh::Manager).to receive(:pwsh_path).and_call_original
 
-          Puppet::Type::Exec::ProviderPwsh.any_instance.expects(:run).
-            with(regexp_matches(native_pwsh_path_regex), false)
-
+          expect(provider).to receive(:run).with(/#{native_pwsh_path}/, false)
           provider.run_spec_override(command)
         end
       end
@@ -97,8 +92,8 @@ describe Puppet::Type.type(:exec).provider(:pwsh) do
     it "should only attempt to find pwsh once when pwsh exists" do
       # Need to unstub to force the 'only once' expectation. Otherwise the
       # previous stub takes over if it's called more than once.
-      Pwsh::Manager.unstub(:pwsh_path)
-      Pwsh::Manager.expects(:pwsh_path).once.returns('somepath/pwsh')
+      allow(Pwsh::Manager).to receive(:pwsh_path).and_call_original
+      expect(Pwsh::Manager).to receive(:pwsh_path).once.and_return('somepath/pwsh')
 
       provider.run_spec_override(command)
       provider.run_spec_override(command)


### PR DESCRIPTION
Prior to this commit, spec tests for pwsh were using old syntax and conventions.

This commit updates the tests so that they match the syntax and conventions being used throughout the rest of our modules.