### PR TITLE
pdksync - (CAT-343) Audit modules and tools for references to travis. Removed all needless references to travis.

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -11,18 +11,18 @@ vagrant:
   - generic/ubuntu1804
   - generic/debian8
   - gusztavvargadr/windows-server
-travis_deb:
+docker_deb:
   provisioner: docker
   images:
   - litmusimage/debian:8
   - litmusimage/debian:9
   - litmusimage/debian:10
-travis_ub:
+docker_ub:
   provisioner: docker
   images:
   - litmusimage/ubuntu:16.04
   - litmusimage/ubuntu:18.04
-travis_el7:
+docker_el7:
   provisioner: docker
   images:
   - litmusimage/centos:7


### PR DESCRIPTION
(CAT-343) Audit modules and tools for references to travis. Removed all needless references to travis.
pdk version: `2.7.0` 
