### PR TITLE
(CAT-1599) - Fixing docker provisioner issue with github runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
+    with:
+      runs_on: "ubuntu-20.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,4 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
-
+    with:
+      runs_on: "ubuntu-20.04"


### PR DESCRIPTION
## Summary

CI is failing with docker provisioner due to filesystem mount issue.

