### PR TITLE
(CAT-1696) - Skip CI pipeline for ARM OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
     secrets: "inherit"
     with:
       runs_on: "ubuntu-20.04"
+      flags: "--exclude-platforms '[\"Ubuntu-22.04-arm\", \"RedHat-9-arm\"]'"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,3 +16,4 @@ jobs:
     secrets: "inherit"
     with:
       runs_on: "ubuntu-20.04"
+      flags: "--exclude-platforms '[\"Ubuntu-22.04-arm\", \"RedHat-9-arm\"]'"


### PR DESCRIPTION
## Summary

Skip CI pipeline for ARM OS due to power-shell package unsupportability. 
```
Last metadata expiration check: 0:01:43 ago on Thu 18 Jan 2024 09:11:38 AM UTC.
Error:
 Problem: cannot install the best candidate for the job
  - package powershell-7.3.11-1.rh.x86_64 from packages-microsoft-com-prod does not have a compatible architecture
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)