### PR TITLE
(CAT-2205): Replaced legacy fact `osfamily` with `os.family`

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,14 +6,14 @@ defaults:  # Used for any hierarchy level that omits these keys.
   data_hash: yaml_data  # Use the built-in YAML backend.
 
 hierarchy:
-  - name: "osfamily/major release"
+  - name: "os.family/major release"
     paths:
         # Used to distinguish between Debian and Ubuntu
       - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
       - "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
         # Used for Solaris
       - "os/%{facts.os.family}/%{facts.kernelrelease}.yaml"
-  - name: "osfamily"
+  - name: "os.family"
     paths:
       - "os/%{facts.os.name}.yaml"
       - "os/%{facts.os.family}.yaml"

--- a/lib/puppet/provider/exec/powershell.rb
+++ b/lib/puppet/provider/exec/powershell.rb
@@ -3,7 +3,7 @@
 require 'puppet/provider/exec'
 
 Puppet::Type.type(:exec).provide :powershell, parent: Puppet::Provider::Exec do
-  confine operatingsystem: :windows
+  confine 'os.name': :windows
   confine feature: :pwshlib
 
   desc <<-DESC


### PR DESCRIPTION
## Summary
Replaced legacy fact `osfamily` with `os.family`

## Additional Context
As a part of making modules 'puppet 8` compatible without deprecation warnings, we are replacing these legacy facts with the updated one.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)