### PR TITLE
Allow puppetlabs-pwshlib 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/pwshlib",
-      "version_requirement": ">= 0.4.0 < 2.0.0"
+      "version_requirement": ">= 0.4.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary
Allowing the latest major release of pwshlib
